### PR TITLE
Make emergency QR open HTML summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -2627,6 +2627,7 @@
 
                 // Emergency QR helpers
                 this.QR_BYTE_LIMIT = 1500;
+                this.QR_TEXT_LIMIT = 900;
                 this.truncationNotice = '\n\n⚠️ Additional emergency details omitted. See vault for full record.';
                 this._textEncoder = new TextEncoder();
 
@@ -3296,7 +3297,25 @@
                 if (warningEl) warningEl.textContent = '';
 
                 const { text: summaryText, hasDetails } = this.buildEmergencySummary();
-                const { text: qrText, truncated } = this.fitTextForQR(summaryText);
+                let maxTextBytes = this.QR_TEXT_LIMIT;
+                let { text: qrText, truncated } = this.fitTextForQR(summaryText, maxTextBytes);
+                let dataUrl = this.buildEmergencyDataUrl(qrText);
+                let encodedLength = this._textEncoder.encode(dataUrl).length;
+
+                while (encodedLength > this.QR_BYTE_LIMIT && maxTextBytes > 200) {
+                    maxTextBytes = Math.floor(maxTextBytes * 0.85);
+                    ({ text: qrText, truncated } = this.fitTextForQR(summaryText, maxTextBytes));
+                    dataUrl = this.buildEmergencyDataUrl(qrText);
+                    encodedLength = this._textEncoder.encode(dataUrl).length;
+                    truncated = true;
+                }
+
+                if (encodedLength > this.QR_BYTE_LIMIT) {
+                    qrText = 'EMERGENCY MEDICAL INFO\nSummary exceeds QR capacity. Access vault for full record.';
+                    dataUrl = this.buildEmergencyDataUrl(qrText);
+                    encodedLength = this._textEncoder.encode(dataUrl).length;
+                    truncated = true;
+                }
 
                 if (previewEl) {
                     previewEl.textContent = qrText;
@@ -3306,14 +3325,18 @@
                 if (warningEl) {
                     if (!hasDetails) {
                         warningEl.textContent = 'Add emergency details to include more information in the QR code.';
-                    } else if (truncated) {
-                        warningEl.textContent = 'Emergency summary shortened to fit inside the QR code. Review the preview for omitted details.';
+                    } else {
+                        const messages = ['Scan with your phone to open this summary in a browser window.'];
+                        if (truncated) {
+                            messages.push('Emergency summary shortened to fit inside the QR code. Review the preview for omitted details.');
+                        }
+                        warningEl.textContent = messages.join(' ');
                     }
                 }
 
                 try {
-                    QRGenerator.generate(qrText, container, { width: 200, height: 200 });
-                    console.log('QR generated with text:', qrText);
+                    QRGenerator.generate(dataUrl, container, { width: 200, height: 200 });
+                    console.log('QR generated with data URL:', dataUrl);
                 } catch (e) {
                     console.error('QR generation failed:', e);
                     this.createFallbackDisplay(container, qrText);
@@ -3321,6 +3344,20 @@
                         warningEl.textContent = 'Unable to render QR code. Emergency summary shown below for quick reference.';
                     }
                 }
+            }
+
+            buildEmergencyHtml(text) {
+                const escaped = text
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;');
+
+                return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Emergency Medical Info</title><style>body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;background:#0f172a;color:#f8fafc;margin:0;padding:24px;}main{max-width:600px;margin:0 auto;background:#1e293b;padding:24px;border-radius:12px;box-shadow:0 20px 60px rgba(15,23,42,0.45);}h1{margin-top:0;font-size:20pt;color:#38bdf8;text-align:center;}p.notice{color:#e2e8f0;font-size:10pt;text-align:center;margin-bottom:20px;}pre{background:#0f172a;border-radius:8px;padding:16px;white-space:pre-wrap;word-break:break-word;font-size:11pt;line-height:1.5;color:#f8fafc;border:1px solid rgba(148,163,184,0.3);}</style></head><body><main><h1>Emergency Medical Info</h1><p class="notice">Provided from your Personal Health Vault QR code.</p><pre>${escaped}</pre></main></body></html>`;
+            }
+
+            buildEmergencyDataUrl(text) {
+                const html = this.buildEmergencyHtml(text);
+                return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
             }
 
             buildEmergencySummary() {
@@ -3424,9 +3461,8 @@
                 return trimmed.split(/[,;]+/).map(item => item.trim()).filter(Boolean);
             }
 
-            fitTextForQR(text) {
+            fitTextForQR(text, maxBytes = this.QR_BYTE_LIMIT) {
                 const encoder = this._textEncoder;
-                const maxBytes = this.QR_BYTE_LIMIT;
                 const bytes = encoder.encode(text);
 
                 if (bytes.length <= maxBytes) {


### PR DESCRIPTION
## Summary
- update the emergency QR generator to encode a self-contained HTML page so scanners open a readable browser view
- add helpers to build the HTML payload and enforce byte limits while preserving the on-screen preview and warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e15a853b708332b53b0569ddb72ffb