### PR TITLE
Improve mobile experience for security actions menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,14 @@
             flex-grow: 0;
             flex-shrink: 0;
         }
-        
+
+        .action-toggle {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: auto;
+        }
+
         .btn {
             padding: 5px 12px;
             border: none;
@@ -1106,15 +1113,27 @@
                 padding: 10px 12px;
             }
 
-            .security-status,
-            .action-buttons {
+            .security-status {
                 width: 100%;
                 justify-content: space-between;
             }
 
+            .action-toggle {
+                display: inline-flex;
+                width: 100%;
+                justify-content: center;
+            }
+
             .action-buttons {
-                flex-wrap: wrap;
-                gap: 6px;
+                display: none;
+                flex-direction: column;
+                gap: 8px;
+                width: 100%;
+                align-items: stretch;
+            }
+
+            .action-buttons.is-open {
+                display: flex;
             }
 
             .save-status {
@@ -1124,8 +1143,7 @@
             }
 
             .action-buttons .btn {
-                flex: 1 1 45%;
-                min-width: 140px;
+                width: 100%;
             }
 
             .nav-tabs {
@@ -1536,7 +1554,10 @@
         <div class="save-status never-saved" id="saveStatus">
             ⚠️ Not Initialized - Create Your Vault
         </div>
-        <div class="action-buttons">
+        <button class="action-toggle btn btn-secondary" id="actionMenuToggle" aria-expanded="false" aria-controls="securityActions">
+            ☰ Vault Actions
+        </button>
+        <div class="action-buttons" id="securityActions">
             <button class="btn btn-secondary" id="settingsBtn">⚙️ Settings</button>
             <button class="btn btn-secondary" id="emergencyQRBtn">🚨 Emergency QR</button>
             <button class="btn btn-lock" id="lockBtn" style="display: none;">🔓 Lock</button>
@@ -2759,6 +2780,39 @@
                 document.getElementById('emergencyQRBtn').addEventListener('click', () => this.openQRGenerator());
                 document.getElementById('exportBtn').addEventListener('click', () => this.openExportOptions());
                 document.getElementById('lockBtn')?.addEventListener('click', () => this.toggleLock());
+
+                const actionButtons = document.getElementById('securityActions');
+                const actionMenuToggle = document.getElementById('actionMenuToggle');
+                if (actionButtons && actionMenuToggle) {
+                    const mobileQuery = window.matchMedia('(max-width: 900px)');
+                    const syncActionMenu = (mq) => {
+                        if (!mq.matches) {
+                            actionButtons.classList.remove('is-open');
+                            actionMenuToggle.setAttribute('aria-expanded', 'false');
+                        }
+                    };
+
+                    actionMenuToggle.addEventListener('click', () => {
+                        const isOpen = actionButtons.classList.toggle('is-open');
+                        actionMenuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                    });
+
+                    actionButtons.querySelectorAll('button').forEach((btn) => {
+                        btn.addEventListener('click', () => {
+                            if (mobileQuery.matches) {
+                                actionButtons.classList.remove('is-open');
+                                actionMenuToggle.setAttribute('aria-expanded', 'false');
+                            }
+                        });
+                    });
+
+                    syncActionMenu(mobileQuery);
+                    if (mobileQuery.addEventListener) {
+                        mobileQuery.addEventListener('change', syncActionMenu);
+                    } else if (mobileQuery.addListener) {
+                        mobileQuery.addListener(syncActionMenu);
+                    }
+                }
 
                 document.getElementById('printSummaryBtn')?.addEventListener('click', () => {
                     this.closeExportOptions();


### PR DESCRIPTION
## Summary
- add a dedicated "Vault Actions" toggle for the security bar on small screens
- adjust mobile styling so action buttons collapse into a vertical list when opened
- ensure the menu closes after selecting an action and when resizing back to desktop widths

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e15fc21c148332909faba582047209