### PR TITLE
Remove Emergency QR UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2862,6 +2862,16 @@
             }
             
             setupEventListeners() {
+                // Remove deprecated Emergency QR functionality if it exists
+                const emergencyQRBtn = document.getElementById('emergencyQRBtn');
+                if (emergencyQRBtn) {
+                    emergencyQRBtn.remove();
+                }
+                // Remove any other Emergency QR elements that might be embedded in legacy files
+                document.querySelectorAll('[id^="emergencyQR"]').forEach((element) => {
+                    element.remove();
+                });
+
                 // Main buttons
                 document.getElementById('saveBtn').addEventListener('click', () => this.saveVault());
                 document.getElementById('settingsBtn').addEventListener('click', () => this.openSettings());


### PR DESCRIPTION
## Summary
- remove any legacy Emergency QR button or related elements during startup so the feature cannot appear

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e1655c95988332bd8d3a69d743cb42