### PR TITLE
Compress attachments with pako

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="expires" content="0">
     <link rel="icon" type="image/x-icon" href="https://storage.googleapis.com/intelechia-content/favicon.ico">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js" integrity="sha512-5Y3OVd9VVKa70BxZ0JItNaJ+uwOxa7Xpu8aHf36JI3hLN3PTTr7X6KhoORmvK+jEbwSwrgPWSlhBu7/52iKR2w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <title>Personal Health Vault - Secure Medical Record</title>
     <style>
         @page {
@@ -5554,7 +5555,7 @@
 
                 for (const file of files) {
                     try {
-                        const base64 = await this.readFileAsBase64(file);
+                        const result = await this.readFileAsBase64(file);
                         const attachment = {
                             id: this.generateAttachmentId(),
                             name: typeof file.name === 'string' && file.name ? file.name : 'attachment',
@@ -5562,8 +5563,18 @@
                             size: typeof file.size === 'number' ? file.size : 0,
                             lastModified: typeof file.lastModified === 'number' ? file.lastModified : null,
                             addedAt: new Date().toISOString(),
-                            data: base64
+                            compressed: !!result?.compressed,
+                            originalSize: typeof result?.originalSize === 'number'
+                                ? result.originalSize
+                                : (typeof file.size === 'number' ? file.size : 0),
+                            compressedSize: typeof result?.compressedSize === 'number'
+                                ? result.compressedSize
+                                : (typeof result?.data === 'string' ? Math.ceil(result.data.length * 3 / 4) : (typeof file.size === 'number' ? file.size : 0)),
+                            data: typeof result?.data === 'string' ? result.data : ''
                         };
+                        if (!attachment.data) {
+                            throw new Error('Attachment data is empty');
+                        }
                         this.attachments.push(attachment);
                     } catch (error) {
                         console.error('Failed to add attachment', error);
@@ -5581,7 +5592,7 @@
                 }
             }
 
-            readFileAsBase64(file) {
+            readFileAsBase64(file, compress = true) {
                 return new Promise((resolve, reject) => {
                     if (!(file instanceof Blob)) {
                         reject(new Error('Invalid file'));
@@ -5594,16 +5605,46 @@
                             const result = reader.result;
                             if (result instanceof ArrayBuffer) {
                                 const bytes = new Uint8Array(result);
+                                let finalBytes = bytes;
+                                let isCompressed = false;
+
+                                if (compress && bytes.length > 1024) {
+                                    const pakoInstance = typeof window !== 'undefined' ? window.pako : null;
+                                    if (pakoInstance && typeof pakoInstance.deflate === 'function') {
+                                        try {
+                                            const compressed = pakoInstance.deflate(bytes, { level: 6 });
+                                            if (compressed && compressed.length < bytes.length) {
+                                                finalBytes = compressed;
+                                                isCompressed = true;
+                                            }
+                                        } catch (compressionError) {
+                                            console.warn('Attachment compression failed, storing uncompressed', compressionError);
+                                        }
+                                    }
+                                }
+
                                 const chunkSize = 0x8000;
                                 let binary = '';
-                                for (let i = 0; i < bytes.length; i += chunkSize) {
-                                    const chunk = bytes.subarray(i, i + chunkSize);
+                                for (let i = 0; i < finalBytes.length; i += chunkSize) {
+                                    const chunk = finalBytes.subarray(i, i + chunkSize);
                                     binary += String.fromCharCode(...chunk);
                                 }
-                                resolve(btoa(binary));
+
+                                resolve({
+                                    data: btoa(binary),
+                                    compressed: isCompressed,
+                                    originalSize: bytes.length,
+                                    compressedSize: finalBytes.length
+                                });
                             } else if (typeof result === 'string') {
                                 const base64Match = result.match(/^data:[^;]+;base64,(.*)$/);
-                                resolve(base64Match ? base64Match[1] : result);
+                                const data = base64Match ? base64Match[1] : result;
+                                resolve({
+                                    data,
+                                    compressed: false,
+                                    originalSize: typeof file.size === 'number' ? file.size : 0,
+                                    compressedSize: typeof file.size === 'number' ? file.size : 0
+                                });
                             } else {
                                 reject(new Error('Unsupported file data'));
                             }
@@ -5725,9 +5766,12 @@
                         name: attachment.name,
                         type: attachment.type,
                         size: attachment.size,
+                        compressed: !!attachment.compressed,
+                        originalSize: typeof attachment.originalSize === 'number' ? attachment.originalSize : (typeof attachment.size === 'number' ? attachment.size : 0),
+                        compressedSize: typeof attachment.compressedSize === 'number' ? attachment.compressedSize : (typeof attachment.data === 'string' ? Math.ceil(attachment.data.length * 3 / 4) : (typeof attachment.size === 'number' ? attachment.size : 0)),
                         lastModified: attachment.lastModified,
                         addedAt: attachment.addedAt,
-                        data: attachment.data
+                        data: typeof attachment.data === 'string' ? attachment.data : ''
                     }))
                     : [];
 
@@ -5772,9 +5816,16 @@
                         name: item.name || 'Attachment',
                         type: item.type || 'application/octet-stream',
                         size: typeof item.size === 'number' ? item.size : 0,
+                        compressed: !!item.compressed,
+                        originalSize: typeof item.originalSize === 'number'
+                            ? item.originalSize
+                            : (typeof item.size === 'number' ? item.size : 0),
+                        compressedSize: typeof item.compressedSize === 'number'
+                            ? item.compressedSize
+                            : (typeof item.data === 'string' ? Math.ceil(item.data.length * 3 / 4) : (typeof item.size === 'number' ? item.size : 0)),
                         lastModified: typeof item.lastModified === 'number' ? item.lastModified : null,
                         addedAt: item.addedAt || new Date().toISOString(),
-                        data: item.data
+                        data: typeof item.data === 'string' ? item.data : ''
                     }));
 
                 this.attachments = sanitized;
@@ -5901,7 +5952,7 @@
                 const mimeType = (attachment.type || 'application/octet-stream').toLowerCase();
 
                 try {
-                    const blob = this.base64ToBlob(attachment.data, attachment.type);
+                    const blob = this.base64ToBlob(attachment.data, attachment.type, attachment.compressed);
 
                     if (mimeType.startsWith('image/')) {
                         const url = URL.createObjectURL(blob);
@@ -5994,7 +6045,7 @@
                 }
 
                 try {
-                    const blob = this.base64ToBlob(attachment.data, attachment.type);
+                    const blob = this.base64ToBlob(attachment.data, attachment.type, attachment.compressed);
                     const url = URL.createObjectURL(blob);
                     const a = document.createElement('a');
                     a.href = url;
@@ -6009,7 +6060,7 @@
                 }
             }
 
-            base64ToBlob(base64, mimeType = 'application/octet-stream') {
+            base64ToBlob(base64, mimeType = 'application/octet-stream', isCompressed = false) {
                 const clean = typeof base64 === 'string' ? base64.trim() : '';
                 if (!clean) {
                     throw new Error('Attachment data is empty.');
@@ -6022,7 +6073,22 @@
                     bytes[i] = binary.charCodeAt(i);
                 }
 
-                return new Blob([bytes], { type: mimeType || 'application/octet-stream' });
+                let finalBytes = bytes;
+                if (isCompressed) {
+                    const pakoInstance = typeof window !== 'undefined' ? window.pako : null;
+                    if (!pakoInstance || typeof pakoInstance.inflate !== 'function') {
+                        throw new Error('Unable to decompress attachment: compression library unavailable.');
+                    }
+
+                    try {
+                        finalBytes = pakoInstance.inflate(bytes);
+                    } catch (error) {
+                        console.error('Failed to decompress attachment', error);
+                        throw new Error('Failed to decompress attachment data.');
+                    }
+                }
+
+                return new Blob([finalBytes], { type: mimeType || 'application/octet-stream' });
             }
 
             initializeExistingNotes() {


### PR DESCRIPTION
## Summary
- load the pako library to enable client-side compression
- compress eligible attachments before base64 encoding and capture compression metadata
- decompress compressed attachments on preview/download and persist the extra metadata

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e35afca33883328ee7e85cd6abac34