### PR TITLE
Compress embedded vault payloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,6 +254,22 @@
             flex: 0 1 340px;
             margin: 0 10px;
         }
+
+        .save-metadata {
+            display: none;
+            flex-direction: column;
+            gap: 2px;
+            font-size: 8.5pt;
+            color: #e2e8f0;
+            text-align: right;
+            line-height: 1.2;
+            flex: 0 1 220px;
+        }
+
+        .save-metadata strong {
+            color: #facc15;
+            font-weight: 700;
+        }
         
         .save-status.never-saved {
             background: #dc2626;
@@ -1385,6 +1401,10 @@
                 justify-content: space-between;
             }
 
+            .save-metadata {
+                display: none !important;
+            }
+
             .action-buttons {
                 flex-wrap: wrap;
                 gap: 6px;
@@ -1474,6 +1494,10 @@
 
             .security-bar {
                 gap: 12px;
+            }
+
+            .save-metadata {
+                display: none !important;
             }
 
             .security-status {
@@ -1812,6 +1836,7 @@
         <div class="save-status never-saved" id="saveStatus">
             ⚠️ Not Initialized - Create Your Vault
         </div>
+        <div class="save-metadata" id="payloadStats" aria-live="polite"></div>
         <div class="action-buttons">
             <button class="btn btn-secondary" id="settingsBtn">⚙️ Settings</button>
             <button class="btn btn-lock" id="lockBtn" style="display: none;">🔓 Lock</button>
@@ -3369,6 +3394,82 @@
                 const num = Math.floor(Math.random() * 1000);
                 return `${adj}-${noun}-${num}`;
             }
+
+            arrayBufferToBase64(buffer) {
+                let view;
+                if (buffer instanceof Uint8Array) {
+                    view = buffer;
+                } else if (buffer instanceof ArrayBuffer) {
+                    view = new Uint8Array(buffer);
+                } else if (buffer && buffer.buffer instanceof ArrayBuffer) {
+                    view = new Uint8Array(buffer.buffer, buffer.byteOffset || 0, buffer.byteLength || buffer.length || 0);
+                } else {
+                    return '';
+                }
+
+                if (!view.length) {
+                    return '';
+                }
+
+                const chunkSize = 0x8000;
+                let binary = '';
+                for (let i = 0; i < view.length; i += chunkSize) {
+                    const chunk = view.subarray(i, i + chunkSize);
+                    binary += String.fromCharCode(...chunk);
+                }
+
+                return btoa(binary);
+            }
+
+            base64ToUint8Array(base64) {
+                if (typeof base64 !== 'string') {
+                    throw new Error('Invalid base64 payload.');
+                }
+
+                const clean = base64.trim();
+                if (!clean) {
+                    return new Uint8Array(0);
+                }
+
+                const binary = atob(clean);
+                const length = binary.length;
+                const bytes = new Uint8Array(length);
+
+                for (let i = 0; i < length; i++) {
+                    bytes[i] = binary.charCodeAt(i);
+                }
+
+                return bytes;
+            }
+
+            normalizeToUint8Array(value) {
+                if (value instanceof Uint8Array) {
+                    return value;
+                }
+
+                if (value instanceof ArrayBuffer) {
+                    return new Uint8Array(value);
+                }
+
+                if (Array.isArray(value)) {
+                    return new Uint8Array(value);
+                }
+
+                if (typeof value === 'string') {
+                    try {
+                        return this.base64ToUint8Array(value);
+                    } catch (error) {
+                        console.warn('Failed to decode base64 payload', error);
+                        return new Uint8Array(0);
+                    }
+                }
+
+                if (value && typeof value === 'object' && value.data && Array.isArray(value.data)) {
+                    return new Uint8Array(value.data);
+                }
+
+                return new Uint8Array(0);
+            }
             
             checkInitialization() {
                 const embeddedData = document.getElementById('embedded-vault-data');
@@ -3439,11 +3540,16 @@
                         if (this.emergencyAccessConfig && this.emergencyAccessConfig.enabled) {
                             this.showEmergencyAccess(this.emergencyAccessConfig.data || {});
                         }
+
+                        this.updatePayloadStats(this.encryptedData);
                     } catch (e) {
                         this.isInitialized = false;
+                        this.encryptedData = null;
+                        this.updatePayloadStats(null);
                     }
                 } else {
                     this.isInitialized = false;
+                    this.encryptedData = null;
                     // Show welcome screen
                     document.getElementById('welcomeScreen').style.display = 'block';
                     document.getElementById('mainContent').style.display = 'none';
@@ -3453,6 +3559,7 @@
                     this.version = APP_VERSION;
                     this.schemaVersion = schemaManager.currentVersion;
                     this.applyVersionMetadata();
+                    this.updatePayloadStats(null);
                 }
             }
 
@@ -4279,7 +4386,7 @@
             updateSaveStatus() {
                 const statusEl = document.getElementById('saveStatus');
                 const saveBtn = document.getElementById('saveBtn');
-                
+
                 if (!this.isInitialized) {
                     statusEl.className = 'save-status never-saved';
                     statusEl.innerHTML = '⚠️ Not Initialized - Create Your Vault';
@@ -4296,6 +4403,76 @@
                     saveBtn.innerHTML = 'Download Current Vault (.ehv)';
                     saveBtn.className = 'btn btn-save saved';
                 }
+            }
+
+            formatBytes(bytes) {
+                if (typeof bytes !== 'number' || !isFinite(bytes) || bytes <= 0) {
+                    return '0 B';
+                }
+
+                const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+                const exponent = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+                const value = bytes / Math.pow(1024, exponent);
+                const decimals = exponent === 0 || value >= 100 ? 0 : value < 10 ? 2 : 1;
+
+                return `${value.toFixed(decimals)} ${units[exponent]}`;
+            }
+
+            updatePayloadStats(encryptedData = null) {
+                const target = document.getElementById('payloadStats');
+
+                if (!target) {
+                    return;
+                }
+
+                if (!encryptedData || typeof encryptedData !== 'object') {
+                    target.innerHTML = '';
+                    target.style.display = 'none';
+                    return;
+                }
+
+                const originalSize = typeof encryptedData.originalSize === 'number' ? encryptedData.originalSize : null;
+                const compressedSize = typeof encryptedData.compressedSize === 'number' ? encryptedData.compressedSize : null;
+                const algorithm = typeof encryptedData.compression === 'string' ? encryptedData.compression : 'none';
+                const reason = typeof encryptedData.compressionReason === 'string' ? encryptedData.compressionReason : '';
+
+                const lines = [];
+
+                if (compressedSize !== null && isFinite(compressedSize)) {
+                    lines.push(`<div><strong>${this.formatBytes(compressedSize)}</strong> stored</div>`);
+                } else if (originalSize !== null && isFinite(originalSize)) {
+                    lines.push(`<div><strong>${this.formatBytes(originalSize)}</strong> stored</div>`);
+                }
+
+                if (algorithm && algorithm !== 'none') {
+                    if (originalSize !== null && compressedSize !== null && originalSize > 0) {
+                        const savings = Math.max(0, originalSize - compressedSize);
+                        const percent = Math.round((savings / originalSize) * 100);
+                        lines.push(`<div>${percent > 0 ? `${percent}% smaller than raw` : 'No size reduction'}</div>`);
+                    }
+
+                    lines.push(`<div style="opacity:0.8;">Compression: ${algorithm.toUpperCase()}</div>`);
+                } else if (originalSize !== null) {
+                    let descriptor = 'Compression: None';
+                    if (reason === 'unsupported') {
+                        descriptor = 'Compression: None (Browser limited)';
+                    } else if (reason === 'noBenefit') {
+                        descriptor = 'Compression: None (Already efficient)';
+                    } else if (reason === 'error') {
+                        descriptor = 'Compression: None (Fallback)';
+                    }
+
+                    lines.push(`<div style="opacity:0.8;">${descriptor}</div>`);
+                }
+
+                if (!lines.length) {
+                    target.innerHTML = '';
+                    target.style.display = 'none';
+                    return;
+                }
+
+                target.innerHTML = lines.join('');
+                target.style.display = 'flex';
             }
             
             async saveVault() {
@@ -4483,6 +4660,9 @@
                 formData.lastUpdated = timestamp;
 
                 const encrypted = await this.crypto.encrypt(formData, password);
+
+                this.encryptedData = encrypted;
+                this.updatePayloadStats(encrypted);
 
                 const htmlDoc = document.documentElement.cloneNode(true);
 
@@ -5712,16 +5892,10 @@
             }
 
             base64ToBlob(base64, mimeType = 'application/octet-stream') {
-                const clean = typeof base64 === 'string' ? base64.trim() : '';
-                if (!clean) {
-                    throw new Error('Attachment data is empty.');
-                }
+                const bytes = this.normalizeToUint8Array(typeof base64 === 'string' ? base64.trim() : base64);
 
-                const binary = atob(clean);
-                const length = binary.length;
-                const bytes = new Uint8Array(length);
-                for (let i = 0; i < length; i++) {
-                    bytes[i] = binary.charCodeAt(i);
+                if (!bytes.length) {
+                    throw new Error('Attachment data is empty.');
                 }
 
                 return new Blob([bytes], { type: mimeType || 'application/octet-stream' });
@@ -6748,9 +6922,122 @@
                 document.getElementById('lockBtn').innerHTML = '🔓 Lock';
             }
             
+            compression = {
+                isSupported: typeof CompressionStream === 'function' && typeof DecompressionStream === 'function',
+
+                compressString: async (text) => {
+                    const encoder = new TextEncoder();
+                    const input = encoder.encode(text);
+                    const originalSize = input.byteLength;
+                    const originalBuffer = this.compression.cloneBuffer(input);
+
+                    if (!this.compression.isSupported) {
+                        return {
+                            algorithm: 'none',
+                            buffer: originalBuffer,
+                            originalSize,
+                            compressedSize: originalSize,
+                            reason: 'unsupported'
+                        };
+                    }
+
+                    try {
+                        const compressedBuffer = await this.compression.compressWithStream(input);
+                        const compressedSize = compressedBuffer.byteLength;
+
+                        if (!compressedSize || compressedSize >= originalSize * 0.95) {
+                            return {
+                                algorithm: 'none',
+                                buffer: originalBuffer,
+                                originalSize,
+                                compressedSize: originalSize,
+                                reason: 'noBenefit'
+                            };
+                        }
+
+                        return {
+                            algorithm: 'gzip',
+                            buffer: compressedBuffer,
+                            originalSize,
+                            compressedSize,
+                            reason: 'compressed'
+                        };
+                    } catch (error) {
+                        console.warn('Compression failed, storing uncompressed payload', error);
+                        return {
+                            algorithm: 'none',
+                            buffer: originalBuffer,
+                            originalSize,
+                            compressedSize: originalSize,
+                            reason: 'error'
+                        };
+                    }
+                },
+
+                decompressToString: async (buffer, algorithm = 'none') => {
+                    const decoder = new TextDecoder();
+
+                    if (!algorithm || algorithm === 'none') {
+                        const view = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : this.normalizeToUint8Array(buffer);
+                        return decoder.decode(view);
+                    }
+
+                    if (algorithm !== 'gzip') {
+                        throw new Error(`Unsupported compression format: ${algorithm}`);
+                    }
+
+                    if (!this.compression.isSupported) {
+                        throw new Error('This vault file uses compression that is not supported in this browser. Please open it in a modern browser.');
+                    }
+
+                    const decompressedBuffer = await this.compression.decompressWithStream(buffer);
+                    return decoder.decode(new Uint8Array(decompressedBuffer));
+                },
+
+                compressWithStream: async (input) => {
+                    const stream = new CompressionStream('gzip');
+                    const writer = stream.writable.getWriter();
+                    await writer.write(input);
+                    await writer.close();
+                    return await new Response(stream.readable).arrayBuffer();
+                },
+
+                decompressWithStream: async (buffer) => {
+                    const source = buffer instanceof ArrayBuffer
+                        ? buffer
+                        : this.compression.cloneBuffer(buffer);
+
+                    const stream = new DecompressionStream('gzip');
+                    const writer = stream.writable.getWriter();
+                    await writer.write(new Uint8Array(source));
+                    await writer.close();
+                    return await new Response(stream.readable).arrayBuffer();
+                },
+
+                cloneBuffer: (value) => {
+                    if (value instanceof ArrayBuffer) {
+                        return value.slice(0);
+                    }
+
+                    if (value instanceof Uint8Array) {
+                        return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+                    }
+
+                    if (Array.isArray(value)) {
+                        return new Uint8Array(value).buffer;
+                    }
+
+                    if (value && value.buffer instanceof ArrayBuffer) {
+                        return value.buffer.slice(value.byteOffset || 0, (value.byteOffset || 0) + (value.byteLength || value.length || 0));
+                    }
+
+                    return new Uint8Array(0).buffer;
+                }
+            };
+
             // Crypto utilities
             crypto = {
-                async deriveKey(password, salt) {
+                deriveKey: async (password, salt) => {
                     const encoder = new TextEncoder();
                     const keyMaterial = await crypto.subtle.importKey(
                         'raw',
@@ -6759,11 +7046,11 @@
                         false,
                         ['deriveBits', 'deriveKey']
                     );
-                    
+
                     return await crypto.subtle.deriveKey(
                         {
                             name: 'PBKDF2',
-                            salt: salt,
+                            salt,
                             iterations: 100000,
                             hash: 'SHA-256'
                         },
@@ -6773,40 +7060,60 @@
                         ['encrypt', 'decrypt']
                     );
                 },
-                
-                async encrypt(data, password) {
-                    const encoder = new TextEncoder();
+
+                encrypt: async (data, password) => {
                     const salt = crypto.getRandomValues(new Uint8Array(16));
                     const iv = crypto.getRandomValues(new Uint8Array(12));
-                    const key = await this.deriveKey(password, salt);
-                    
-                    const encrypted = await crypto.subtle.encrypt(
-                        { name: 'AES-GCM', iv: iv },
+                    const compressionResult = await this.compression.compressString(JSON.stringify(data));
+                    const key = await this.crypto.deriveKey(password, salt);
+
+                    const encryptedBuffer = await crypto.subtle.encrypt(
+                        { name: 'AES-GCM', iv },
                         key,
-                        encoder.encode(JSON.stringify(data))
+                        compressionResult.buffer
                     );
-                    
+
+                    const encryptedBytes = new Uint8Array(encryptedBuffer);
+
                     return {
-                        salt: Array.from(salt),
-                        iv: Array.from(iv),
-                        data: Array.from(new Uint8Array(encrypted))
+                        salt: this.arrayBufferToBase64(salt),
+                        iv: this.arrayBufferToBase64(iv),
+                        data: this.arrayBufferToBase64(encryptedBytes),
+                        encoding: 'base64',
+                        compression: compressionResult.algorithm,
+                        compressionReason: compressionResult.reason,
+                        originalSize: compressionResult.originalSize,
+                        compressedSize: compressionResult.compressedSize
                     };
                 },
-                
-                async decrypt(encryptedData, password) {
-                    const salt = new Uint8Array(encryptedData.salt);
-                    const iv = new Uint8Array(encryptedData.iv);
-                    const data = new Uint8Array(encryptedData.data);
-                    const key = await this.deriveKey(password, salt);
-                    
-                    const decrypted = await crypto.subtle.decrypt(
-                        { name: 'AES-GCM', iv: iv },
+
+                decrypt: async (encryptedData, password) => {
+                    if (!encryptedData || typeof encryptedData !== 'object') {
+                        throw new Error('The encrypted payload could not be read.');
+                    }
+
+                    const saltBytes = this.normalizeToUint8Array(encryptedData.salt);
+                    const ivBytes = this.normalizeToUint8Array(encryptedData.iv);
+                    const dataBytes = this.normalizeToUint8Array(encryptedData.data);
+
+                    if (!saltBytes.length || !ivBytes.length || !dataBytes.length) {
+                        throw new Error('The encrypted data is incomplete or corrupted.');
+                    }
+
+                    const key = await this.crypto.deriveKey(password, saltBytes);
+
+                    const decryptedBuffer = await crypto.subtle.decrypt(
+                        { name: 'AES-GCM', iv: ivBytes },
                         key,
-                        data
+                        dataBytes
                     );
-                    
-                    const decoder = new TextDecoder();
-                    return JSON.parse(decoder.decode(decrypted));
+
+                    const compressionAlgorithm = typeof encryptedData.compression === 'string'
+                        ? encryptedData.compression
+                        : 'none';
+
+                    const decryptedText = await this.compression.decompressToString(decryptedBuffer, compressionAlgorithm);
+                    return JSON.parse(decryptedText);
                 }
             };
         }


### PR DESCRIPTION
## Summary
- compress encrypted vault data with built-in gzip streams and store it as base64 to shrink embedded content
- update decryption, import, and attachment helpers to understand the new payload format while remaining backward compatible
- surface vault payload size and compression details in the header with responsive styling tweaks

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e35870f9048332b8ae9adc5aef2a0a