### PR TITLE
Improve navigation tabs layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             color: #1e293b;
             background: white;
             padding: 20px;
-            padding-top: 105px;
+            padding-top: 160px;
         }
         
         .unlock-screen {
@@ -507,9 +507,11 @@
             background: #f8fafc;
             border-bottom: 1px solid #e2e8f0;
             z-index: 999;
-            overflow-x: auto;
-            white-space: nowrap;
-            padding: 0 20px;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: flex-end;
+            gap: 6px 12px;
+            padding: 8px 20px 6px;
             scrollbar-width: thin;
         }
         
@@ -523,7 +525,10 @@
         }
         
         .tab {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
             padding: 12px 20px;
             cursor: pointer;
             border-bottom: 3px solid transparent;
@@ -531,6 +536,8 @@
             font-size: 10pt;
             font-weight: 500;
             color: #64748b;
+            flex: 0 1 auto;
+            min-width: 0;
         }
         
         .tab:hover {
@@ -1517,7 +1524,7 @@
         @media (max-width: 900px) {
             body {
                 padding: 15px;
-                padding-top: 150px;
+                padding-top: 210px;
                 font-size: 10.5pt;
             }
 
@@ -1585,13 +1592,15 @@
             }
 
             .nav-tabs {
-                top: 68px;
-                padding: 0 12px;
+                top: 120px;
+                padding: 8px 12px 6px;
+                gap: 6px 8px;
             }
 
             .tab {
                 padding: 10px 14px;
                 font-size: 9pt;
+                gap: 4px;
             }
 
             .chart-header-top {
@@ -1646,7 +1655,7 @@
         @media (max-width: 600px) {
             body {
                 padding: 12px;
-                padding-top: 170px;
+                padding-top: 260px;
             }
 
             .unlock-container {
@@ -1935,17 +1944,19 @@
             
             body {
                 padding: 10px;
-                padding-top: 140px;
+                padding-top: 240px;
             }
-            
+
             .nav-tabs {
-                padding: 0 10px;
-                top: 100px;
+                padding: 8px 10px 6px;
+                top: 160px;
+                gap: 6px;
             }
-            
+
             .tab {
                 padding: 10px 15px;
                 font-size: 9pt;
+                gap: 4px;
             }
             
             .demo-field {


### PR DESCRIPTION
## Summary
- switch the fixed navigation container to a wrapping flex layout and tweak tab styles for flex compatibility
- raise body padding and responsive offsets so multi-line navs clear the main content

## Testing
- Manual verification on desktop viewport (Playwright)

------
https://chatgpt.com/codex/tasks/task_b_68e3e4539b208332a6a980c02ba840cc