### PR TITLE
Fix care_connect locale translations

### DIFF
--- a/translations.json
+++ b/translations.json
@@ -2,7 +2,7 @@
   "care_connect": {
     "actions": {
       "ar": "الإجراءات",
-      "en": "Действия",
+      "en": "Actions",
       "es": "Acciones",
       "fil": "Mga Aksyon",
       "fr": "Actions",
@@ -10,15 +10,15 @@
       "kmr": "Çalakî",
       "ko": "작업",
       "pt-BR": "Ações",
-      "ru": "Actions",
+      "ru": "Действия",
       "so": "Ficillada",
       "vi": "Hành động",
       "zh-Hans": "操作",
-      "my": "Действия"
+      "my": "လုပ်ဆောင်မှုများ"
     },
     "active": {
       "ar": "نشط",
-      "en": "Активен",
+      "en": "Active",
       "es": "Activo",
       "fil": "Aktibo",
       "fr": "Actif",
@@ -26,15 +26,15 @@
       "kmr": "Çalak",
       "ko": "활성",
       "pt-BR": "Ativo",
-      "ru": "Active",
+      "ru": "Активен",
       "so": "Firfircoon",
       "vi": "Hoạt động",
       "zh-Hans": "活跃",
-      "my": "Активен"
+      "my": "တက်ကြွ"
     },
     "add": {
       "ar": "إضافة",
-      "en": "Добавить",
+      "en": "Add",
       "es": "Agregar",
       "fil": "Magdagdag",
       "fr": "Ajouter",
@@ -42,11 +42,11 @@
       "kmr": "Lê Zêde Bike",
       "ko": "추가",
       "pt-BR": "Adicionar",
-      "ru": "Add",
+      "ru": "Добавить",
       "so": "Ku Dar",
       "vi": "Thêm",
       "zh-Hans": "添加",
-      "my": "Добавить"
+      "my": "ထည့်ပါ"
     },
     "add_condition": {
       "ar": "+ إضافة شرط",
@@ -82,7 +82,7 @@
     },
     "add_note": {
       "ar": "إضافة ملاحظة",
-      "en": "Добавить Заметку",
+      "en": "Add Note",
       "es": "Agregar Nota",
       "fil": "Magdagdag ng Tala",
       "fr": "Ajouter une Note",
@@ -90,15 +90,15 @@
       "kmr": "Têbînî Lê Zêde Bike",
       "ko": "메모 추가",
       "pt-BR": "Adicionar Nota",
-      "ru": "Add Note",
+      "ru": "Добавить Заметку",
       "so": "Ku Dar Qoraal",
       "vi": "Thêm Ghi chú",
       "zh-Hans": "添加笔记",
-      "my": "Добавить Заметку"
+      "my": "မှတ်စုထည့်ပါ"
     },
     "add_user": {
       "ar": "إضافة مستخدم",
-      "en": "Добавить Пользователя",
+      "en": "Add User",
       "es": "Agregar Usuario",
       "fil": "Magdagdag ng User",
       "fr": "Ajouter un Utilisateur",
@@ -106,11 +106,11 @@
       "kmr": "Bikarhêner Lê Zêde Bike",
       "ko": "사용자 추가",
       "pt-BR": "Adicionar Usuário",
-      "ru": "Add User",
+      "ru": "Добавить Пользователя",
       "so": "Ku Dar Isticmaale",
       "vi": "Thêm Người dùng",
       "zh-Hans": "添加用户",
-      "my": "Добавить Пользователя"
+      "my": "အသုံးပြုသူထည့်ပါ"
     },
     "address": {
       "ar": "العنوان",
@@ -146,7 +146,7 @@
     },
     "age": {
       "ar": "العمر",
-      "en": "Возраст",
+      "en": "Age",
       "es": "Edad",
       "fil": "Edad",
       "fr": "Âge",
@@ -154,15 +154,15 @@
       "kmr": "Temen",
       "ko": "나이",
       "pt-BR": "Idade",
-      "ru": "Age",
+      "ru": "Возраст",
       "so": "Da'da",
       "vi": "Tuổi",
       "zh-Hans": "年龄",
-      "my": "Возраст"
+      "my": "အသက်"
     },
     "alert": {
       "ar": "تنبيه",
-      "en": "Оповещение",
+      "en": "Alert",
       "es": "Alerta",
       "fil": "Alerto",
       "fr": "Alerte",
@@ -170,15 +170,15 @@
       "kmr": "Hişyarî",
       "ko": "경고",
       "pt-BR": "Alerta",
-      "ru": "Alert",
+      "ru": "Оповещение",
       "so": "Digniin",
       "vi": "Cảnh báo",
       "zh-Hans": "警报",
-      "my": "Оповещение"
+      "my": "သတိပေးချက်"
     },
     "all": {
       "ar": "الكل",
-      "en": "Все",
+      "en": "All",
       "es": "Todos",
       "fil": "Lahat",
       "fr": "Tous",
@@ -186,11 +186,11 @@
       "kmr": "Hemû",
       "ko": "전체",
       "pt-BR": "Todos",
-      "ru": "All",
+      "ru": "Все",
       "so": "Dhammaan",
       "vi": "Tất cả",
       "zh-Hans": "全部",
-      "my": "Все"
+      "my": "အားလုံး"
     },
     "all_users": {
       "ar": "جميع المستخدمين",
@@ -306,7 +306,7 @@
     },
     "assigned": {
       "ar": "مسند",
-      "en": "Назначено",
+      "en": "Assigned",
       "es": "Asignado",
       "fil": "Itinalaga",
       "fr": "Assigné",
@@ -314,11 +314,11 @@
       "kmr": "Hatiye Diyarkirin",
       "ko": "할당됨",
       "pt-BR": "Atribuído",
-      "ru": "Assigned",
+      "ru": "Назначено",
       "so": "Loo Xilsaaray",
       "vi": "Đã giao",
       "zh-Hans": "已分配",
-      "my": "Назначено"
+      "my": "ခန့်အပ်ထားသည်"
     },
     "assigned_to": {
       "ar": "مسند إلى",
@@ -338,7 +338,7 @@
     },
     "attachment": {
       "ar": "مرفق",
-      "en": "Вложение",
+      "en": "Attachment",
       "es": "Archivo Adjunto",
       "fil": "Attachment",
       "fr": "Pièce Jointe",
@@ -346,15 +346,15 @@
       "kmr": "Pêvek",
       "ko": "첨부파일",
       "pt-BR": "Anexo",
-      "ru": "Attachment",
+      "ru": "Вложение",
       "so": "Lifaaq",
       "vi": "Tệp đính kèm",
       "zh-Hans": "附件",
-      "my": "Вложение"
+      "my": "ပူးတွဲဖိုင်"
     },
     "attachments": {
       "ar": "المرفقات",
-      "en": "Вложения",
+      "en": "Attachments",
       "es": "Archivos Adjuntos",
       "fil": "Mga Attachment",
       "fr": "Pièces Jointes",
@@ -362,11 +362,11 @@
       "kmr": "Pêvek",
       "ko": "첨부파일",
       "pt-BR": "Anexos",
-      "ru": "Attachments",
+      "ru": "Вложения",
       "so": "Lifaaqyo",
       "vi": "Tệp đính kèm",
       "zh-Hans": "附件",
-      "my": "Вложения"
+      "my": "ပူးတွဲဖိုင်များ"
     },
     "back": {
       "ar": "رجوع",
@@ -418,7 +418,7 @@
     },
     "case": {
       "ar": "حالة",
-      "en": "Дело",
+      "en": "Case",
       "es": "Caso",
       "fil": "Kaso",
       "fr": "Cas",
@@ -426,11 +426,11 @@
       "kmr": "Rewş",
       "ko": "사례",
       "pt-BR": "Caso",
-      "ru": "Case",
+      "ru": "Дело",
       "so": "Kiis",
       "vi": "Trường hợp",
       "zh-Hans": "案例",
-      "my": "Дело"
+      "my": "ကိစ္စ"
     },
     "case_details": {
       "ar": "تفاصيل الحالة",
@@ -450,7 +450,7 @@
     },
     "case_id": {
       "ar": "معرف الحالة",
-      "en": "ID Дела",
+      "en": "Case ID",
       "es": "ID del Caso",
       "fil": "ID ng Kaso",
       "fr": "ID du Cas",
@@ -458,11 +458,11 @@
       "kmr": "Naskirina Rewşê",
       "ko": "사례 ID",
       "pt-BR": "ID do Caso",
-      "ru": "Case ID",
+      "ru": "ID Дела",
       "so": "Aqoonsiga Kiiska",
       "vi": "ID Trường hợp",
       "zh-Hans": "案例ID",
-      "my": "ID Дела"
+      "my": "ကိစ္စ ID"
     },
     "case_manager": {
       "ar": "مدير الحالة",
@@ -498,7 +498,7 @@
     },
     "case_status": {
       "ar": "حالة القضية",
-      "en": "Статус Дела",
+      "en": "Case Status",
       "es": "Estado del Caso",
       "fil": "Katayuan ng Kaso",
       "fr": "Statut du Cas",
@@ -506,11 +506,11 @@
       "kmr": "Rewşa Rewşê",
       "ko": "사례 상태",
       "pt-BR": "Status do Caso",
-      "ru": "Case Status",
+      "ru": "Статус Дела",
       "so": "Xaaladda Kiiska",
       "vi": "Trạng thái Trường hợp",
       "zh-Hans": "案例状态",
-      "my": "Статус Дела"
+      "my": "ကိစ္စအခြေအနေ"
     },
     "cases": {
       "ar": "الحالات",
@@ -690,7 +690,7 @@
     },
     "closed": {
       "ar": "مغلق",
-      "en": "Закрыто",
+      "en": "Closed",
       "es": "Cerrado",
       "fil": "Sarado",
       "fr": "Fermé",
@@ -698,15 +698,15 @@
       "kmr": "Girtî",
       "ko": "마감",
       "pt-BR": "Fechado",
-      "ru": "Closed",
+      "ru": "Закрыто",
       "so": "Xiran",
       "vi": "Đã đóng",
       "zh-Hans": "已关闭",
-      "my": "Закрыто"
+      "my": "ပိတ်ပြီးပါပြီ"
     },
     "comment": {
       "ar": "تعليق",
-      "en": "Комментарий",
+      "en": "Comment",
       "es": "Comentario",
       "fil": "Komento",
       "fr": "Commentaire",
@@ -714,15 +714,15 @@
       "kmr": "Şîrove",
       "ko": "댓글",
       "pt-BR": "Comentário",
-      "ru": "Comment",
+      "ru": "Комментарий",
       "so": "Faallo",
       "vi": "Bình luận",
       "zh-Hans": "评论",
-      "my": "Комментарий"
+      "my": "မှတ်ချက်"
     },
     "comments": {
       "ar": "التعليقات",
-      "en": "Комментарии",
+      "en": "Comments",
       "es": "Comentarios",
       "fil": "Mga Komento",
       "fr": "Commentaires",
@@ -730,15 +730,15 @@
       "kmr": "Şîrove",
       "ko": "댓글",
       "pt-BR": "Comentários",
-      "ru": "Comments",
+      "ru": "Комментарии",
       "so": "Faallooyinka",
       "vi": "Bình luận",
       "zh-Hans": "评论",
-      "my": "Комментарии"
+      "my": "မှတ်ချက်များ"
     },
     "complete": {
       "ar": "إكمال",
-      "en": "Завершить",
+      "en": "Complete",
       "es": "Completar",
       "fil": "Kumpletuhin",
       "fr": "Compléter",
@@ -746,15 +746,15 @@
       "kmr": "Temam Bike",
       "ko": "완료",
       "pt-BR": "Concluir",
-      "ru": "Complete",
+      "ru": "Завершить",
       "so": "Dhammaystir",
       "vi": "Hoàn thành",
       "zh-Hans": "完成",
-      "my": "Завершить"
+      "my": "ပြီးမြောက်အောင်လုပ်ပါ"
     },
     "completed": {
       "ar": "مكتمل",
-      "en": "Завершено",
+      "en": "Completed",
       "es": "Completado",
       "fil": "Nakumpleto",
       "fr": "Complété",
@@ -762,11 +762,11 @@
       "kmr": "Temam Bû",
       "ko": "완료됨",
       "pt-BR": "Concluído",
-      "ru": "Completed",
+      "ru": "Завершено",
       "so": "Dhammaystiran",
       "vi": "Đã hoàn thành",
       "zh-Hans": "已完成",
-      "my": "Завершено"
+      "my": "ပြီးမြောက်ပြီးပါပြီ"
     },
     "confirm": {
       "ar": "تأكيد",
@@ -850,7 +850,7 @@
     },
     "country": {
       "ar": "البلد",
-      "en": "Страна",
+      "en": "Country",
       "es": "País",
       "fil": "Bansa",
       "fr": "Pays",
@@ -858,11 +858,11 @@
       "kmr": "Welat",
       "ko": "국가",
       "pt-BR": "País",
-      "ru": "Country",
+      "ru": "Страна",
       "so": "Dalka",
       "vi": "Quốc gia",
       "zh-Hans": "国家",
-      "my": "Страна"
+      "my": "နိုင်ငံ"
     },
     "create": {
       "ar": "إنشاء",
@@ -962,7 +962,7 @@
     },
     "critical": {
       "ar": "حرج",
-      "en": "Критический",
+      "en": "Critical",
       "es": "Crítico",
       "fil": "Kritikal",
       "fr": "Critique",
@@ -970,11 +970,11 @@
       "kmr": "Giring",
       "ko": "긴급",
       "pt-BR": "Crítico",
-      "ru": "Critical",
+      "ru": "Критический",
       "so": "Aad u Muhiim",
       "vi": "Nghiêm trọng",
       "zh-Hans": "紧急",
-      "my": "Критический"
+      "my": "အရေးကြီး"
     },
     "current_password": {
       "ar": "كلمة المرور الحالية",
@@ -1026,7 +1026,7 @@
     },
     "date_created": {
       "ar": "تاريخ الإنشاء",
-      "en": "Дата Создания",
+      "en": "Date Created",
       "es": "Fecha de Creación",
       "fil": "Petsa ng Paglikha",
       "fr": "Date de Création",
@@ -1034,11 +1034,11 @@
       "kmr": "Dîroka Afirandinê",
       "ko": "생성일",
       "pt-BR": "Data de Criação",
-      "ru": "Date Created",
+      "ru": "Дата Создания",
       "so": "Taariikhda La Sameeyay",
       "vi": "Ngày tạo",
       "zh-Hans": "创建日期",
-      "my": "Дата Создания"
+      "my": "ဖန်တီးသည့်ရက်"
     },
     "date_of_birth": {
       "ar": "تاريخ الميلاد",
@@ -1106,7 +1106,7 @@
     },
     "details": {
       "ar": "التفاصيل",
-      "en": "Детали",
+      "en": "Details",
       "es": "Detalles",
       "fil": "Mga Detalye",
       "fr": "Détails",
@@ -1114,15 +1114,15 @@
       "kmr": "Hûrgulî",
       "ko": "세부정보",
       "pt-BR": "Detalhes",
-      "ru": "Details",
+      "ru": "Детали",
       "so": "Faahfaahin",
       "vi": "Chi tiết",
       "zh-Hans": "详情",
-      "my": "Детали"
+      "my": "အသေးစိတ်"
     },
     "dob": {
       "ar": "تاريخ الميلاد",
-      "en": "Дата Рождения",
+      "en": "DOB",
       "es": "Fecha de Nacimiento",
       "fil": "Petsa ng Kapanganakan",
       "fr": "Date de Naissance",
@@ -1130,11 +1130,11 @@
       "kmr": "Dîroka Jidayikbûnê",
       "ko": "생년월일",
       "pt-BR": "Data de Nascimento",
-      "ru": "DOB",
+      "ru": "Дата Рождения",
       "so": "Taariikhda Dhalashada",
       "vi": "Ngày sinh",
       "zh-Hans": "出生日期",
-      "my": "Дата Рождения"
+      "my": "မွေးသက္ကရာဇ်"
     },
     "documents": {
       "ar": "المستندات",
@@ -1170,7 +1170,7 @@
     },
     "due_date": {
       "ar": "تاريخ الاستحقاق",
-      "en": "Срок Выполнения",
+      "en": "Due Date",
       "es": "Fecha de Vencimiento",
       "fil": "Deadline",
       "fr": "Date d'Échéance",
@@ -1178,15 +1178,15 @@
       "kmr": "Dîroka Dawî",
       "ko": "마감일",
       "pt-BR": "Data de Vencimento",
-      "ru": "Due Date",
+      "ru": "Срок Выполнения",
       "so": "Taariikhda Ugu Dambeeyay",
       "vi": "Hạn chót",
       "zh-Hans": "截止日期",
-      "my": "Срок Выполнения"
+      "my": "သတ်မှတ်ထားသည့်ရက်"
     },
     "duration": {
       "ar": "المدة",
-      "en": "Продолжительность",
+      "en": "Duration",
       "es": "Duración",
       "fil": "Tagal",
       "fr": "Durée",
@@ -1194,11 +1194,11 @@
       "kmr": "Dem",
       "ko": "기간",
       "pt-BR": "Duração",
-      "ru": "Duration",
+      "ru": "Продолжительность",
       "so": "Muddada",
       "vi": "Thời lượng",
       "zh-Hans": "持续时间",
-      "my": "Продолжительность"
+      "my": "ကြာချိန်"
     },
     "edit": {
       "ar": "تعديل",
@@ -1218,7 +1218,7 @@
     },
     "edit_case": {
       "ar": "تعديل الحالة",
-      "en": "Редактировать Дело",
+      "en": "Edit Case",
       "es": "Editar Caso",
       "fil": "I-edit ang Kaso",
       "fr": "Modifier le Cas",
@@ -1226,15 +1226,15 @@
       "kmr": "Rewşê Biguherîne",
       "ko": "사례 편집",
       "pt-BR": "Editar Caso",
-      "ru": "Edit Case",
+      "ru": "Редактировать Дело",
       "so": "Wax Ka Bedel Kiiska",
       "vi": "Chỉnh sửa Trường hợp",
       "zh-Hans": "编辑案例",
-      "my": "Редактировать Дело"
+      "my": "ကိစ္စကို တည်းဖြတ်ပါ"
     },
     "edit_client": {
       "ar": "تعديل العميل",
-      "en": "Редактировать Клиента",
+      "en": "Edit Client",
       "es": "Editar Cliente",
       "fil": "I-edit ang Kliyente",
       "fr": "Modifier le Client",
@@ -1242,11 +1242,11 @@
       "kmr": "Xerîdar Biguherîne",
       "ko": "고객 편집",
       "pt-BR": "Editar Cliente",
-      "ru": "Edit Client",
+      "ru": "Редактировать Клиента",
       "so": "Wax Ka Bedel Macmiilka",
       "vi": "Chỉnh sửa Khách hàng",
       "zh-Hans": "编辑客户",
-      "my": "Редактировать Клиента"
+      "my": "ဖောက်သည်ကို တည်းဖြတ်ပါ"
     },
     "edit_profile": {
       "ar": "تعديل الملف الشخصي",
@@ -1506,7 +1506,7 @@
     },
     "high": {
       "ar": "عالية",
-      "en": "Высокий",
+      "en": "High",
       "es": "Alto",
       "fil": "Mataas",
       "fr": "Élevé",
@@ -1514,15 +1514,15 @@
       "kmr": "Bilind",
       "ko": "높음",
       "pt-BR": "Alta",
-      "ru": "High",
+      "ru": "Высокий",
       "so": "Sare",
       "vi": "Cao",
       "zh-Hans": "高",
-      "my": "Высокий"
+      "my": "မြင့်"
     },
     "history": {
       "ar": "السجل",
-      "en": "История",
+      "en": "History",
       "es": "Historial",
       "fil": "Kasaysayan",
       "fr": "Historique",
@@ -1530,11 +1530,11 @@
       "kmr": "Dîrok",
       "ko": "이력",
       "pt-BR": "Histórico",
-      "ru": "History",
+      "ru": "История",
       "so": "Taariikh",
       "vi": "Lịch sử",
       "zh-Hans": "历史",
-      "my": "История"
+      "my": "မှတ်တမ်း"
     },
     "home": {
       "ar": "الرئيسية",
@@ -1714,7 +1714,7 @@
     },
     "low": {
       "ar": "منخفض",
-      "en": "Низкий",
+      "en": "Low",
       "es": "Bajo",
       "fil": "Mababa",
       "fr": "Faible",
@@ -1722,11 +1722,11 @@
       "kmr": "Nizm",
       "ko": "낮음",
       "pt-BR": "Baixa",
-      "ru": "Low",
+      "ru": "Низкий",
       "so": "Hoose",
       "vi": "Thấp",
       "zh-Hans": "低",
-      "my": "Низкий"
+      "my": "နိမ့်"
     },
     "male": {
       "ar": "ذكر",
@@ -1762,7 +1762,7 @@
     },
     "medium": {
       "ar": "متوسط",
-      "en": "Средний",
+      "en": "Medium",
       "es": "Medio",
       "fil": "Katamtaman",
       "fr": "Moyen",
@@ -1770,11 +1770,11 @@
       "kmr": "Navîn",
       "ko": "보통",
       "pt-BR": "Média",
-      "ru": "Medium",
+      "ru": "Средний",
       "so": "Dhexdhexaad",
       "vi": "Trung bình",
       "zh-Hans": "中",
-      "my": "Средний"
+      "my": "အလယ်"
     },
     "message": {
       "ar": "رسالة",
@@ -1842,7 +1842,7 @@
     },
     "new": {
       "ar": "جديد",
-      "en": "Новый",
+      "en": "New",
       "es": "Nuevo",
       "fil": "Bago",
       "fr": "Nouveau",
@@ -1850,11 +1850,11 @@
       "kmr": "Nû",
       "ko": "새로운",
       "pt-BR": "Novo",
-      "ru": "New",
+      "ru": "Новый",
       "so": "Cusub",
       "vi": "Mới",
       "zh-Hans": "新",
-      "my": "Новый"
+      "my": "အသစ်"
     },
     "new_case": {
       "ar": "حالة جديدة",
@@ -2002,7 +2002,7 @@
     },
     "notification": {
       "ar": "إشعار",
-      "en": "Уведомление",
+      "en": "Notification",
       "es": "Notificación",
       "fil": "Notification",
       "fr": "Notification",
@@ -2010,11 +2010,11 @@
       "kmr": "Agahdarî",
       "ko": "알림",
       "pt-BR": "Notificação",
-      "ru": "Notification",
+      "ru": "Уведомление",
       "so": "Ogeysiin",
       "vi": "Thông báo",
       "zh-Hans": "通知",
-      "my": "Уведомление"
+      "my": "အသိပေးချက်"
     },
     "notifications": {
       "ar": "الإشعارات",
@@ -2066,7 +2066,7 @@
     },
     "overview": {
       "ar": "نظرة عامة",
-      "en": "Обзор",
+      "en": "Overview",
       "es": "Resumen General",
       "fil": "Pangkalahatang-ideya",
       "fr": "Aperçu",
@@ -2074,11 +2074,11 @@
       "kmr": "Bernameyên Giştî",
       "ko": "개요",
       "pt-BR": "Visão Geral",
-      "ru": "Overview",
+      "ru": "Обзор",
       "so": "Dulmar Guud",
       "vi": "Tổng quan",
       "zh-Hans": "概览",
-      "my": "Обзор"
+      "my": "အကျဉ်းချုပ်"
     },
     "password": {
       "ar": "كلمة المرور",
@@ -2274,7 +2274,7 @@
     },
     "provider": {
       "ar": "مزود الخدمة",
-      "en": "Поставщик",
+      "en": "Provider",
       "es": "Proveedor",
       "fil": "Provider",
       "fr": "Fournisseur",
@@ -2282,15 +2282,15 @@
       "kmr": "Pêşkêşker",
       "ko": "제공자",
       "pt-BR": "Provedor",
-      "ru": "Provider",
+      "ru": "Поставщик",
       "so": "Bixiyaha",
       "vi": "Nhà cung cấp",
       "zh-Hans": "提供者",
-      "my": "Поставщик"
+      "my": "ဝန်ဆောင်မှုပေးသူ"
     },
     "recent": {
       "ar": "حديث",
-      "en": "Недавние",
+      "en": "Recent",
       "es": "Reciente",
       "fil": "Kamakailan",
       "fr": "Récent",
@@ -2298,15 +2298,15 @@
       "kmr": "Nûtir",
       "ko": "최근",
       "pt-BR": "Recente",
-      "ru": "Recent",
+      "ru": "Недавние",
       "so": "Dhawaan",
       "vi": "Gần đây",
       "zh-Hans": "最近",
-      "my": "Недавние"
+      "my": "မကြာသေးမီ"
     },
     "record": {
       "ar": "سجل",
-      "en": "Запись",
+      "en": "Record",
       "es": "Registro",
       "fil": "Rekord",
       "fr": "Dossier",
@@ -2314,15 +2314,15 @@
       "kmr": "Tomar",
       "ko": "기록",
       "pt-BR": "Registro",
-      "ru": "Record",
+      "ru": "Запись",
       "so": "Diiwaanka",
       "vi": "Hồ sơ",
       "zh-Hans": "记录",
-      "my": "Запись"
+      "my": "မှတ်တမ်း"
     },
     "records": {
       "ar": "السجلات",
-      "en": "Записи",
+      "en": "Records",
       "es": "Registros",
       "fil": "Mga Rekord",
       "fr": "Dossiers",
@@ -2330,11 +2330,11 @@
       "kmr": "Tomar",
       "ko": "기록",
       "pt-BR": "Registros",
-      "ru": "Records",
+      "ru": "Записи",
       "so": "Diiwaannada",
       "vi": "Hồ sơ",
       "zh-Hans": "记录",
-      "my": "Записи"
+      "my": "မှတ်တမ်းများ"
     },
     "referred_by": {
       "ar": "إحالة من",
@@ -2466,7 +2466,7 @@
     },
     "resolved": {
       "ar": "تم الحل",
-      "en": "Решено",
+      "en": "Resolved",
       "es": "Resuelto",
       "fil": "Nalutas",
       "fr": "Résolu",
@@ -2474,11 +2474,11 @@
       "kmr": "Hate Çareserkirin",
       "ko": "해결됨",
       "pt-BR": "Resolvido",
-      "ru": "Resolved",
+      "ru": "Решено",
       "so": "La Xalliyay",
       "vi": "Đã giải quyết",
       "zh-Hans": "已解决",
-      "my": "Решено"
+      "my": "ဖြေရှင်းပြီးပါပြီ"
     },
     "role": {
       "ar": "الدور",
@@ -2530,7 +2530,7 @@
     },
     "schedule": {
       "ar": "الجدول الزمني",
-      "en": "Расписание",
+      "en": "Schedule",
       "es": "Horario",
       "fil": "Iskedyul",
       "fr": "Calendrier",
@@ -2538,11 +2538,11 @@
       "kmr": "Bernameyê Demê",
       "ko": "일정",
       "pt-BR": "Agenda",
-      "ru": "Schedule",
+      "ru": "Расписание",
       "so": "Jadwalka",
       "vi": "Lịch trình",
       "zh-Hans": "日程",
-      "my": "Расписание"
+      "my": "အချိန်ဇယား"
     },
     "search": {
       "ar": "بحث",
@@ -2658,7 +2658,7 @@
     },
     "service": {
       "ar": "خدمة",
-      "en": "Услуга",
+      "en": "Service",
       "es": "Servicio",
       "fil": "Serbisyo",
       "fr": "Service",
@@ -2666,15 +2666,15 @@
       "kmr": "Karûbar",
       "ko": "서비스",
       "pt-BR": "Serviço",
-      "ru": "Service",
+      "ru": "Услуга",
       "so": "Adeeg",
       "vi": "Dịch vụ",
       "zh-Hans": "服务",
-      "my": "Услуга"
+      "my": "ဝန်ဆောင်မှု"
     },
     "services": {
       "ar": "الخدمات",
-      "en": "Услуги",
+      "en": "Services",
       "es": "Servicios",
       "fil": "Mga Serbisyo",
       "fr": "Services",
@@ -2682,11 +2682,11 @@
       "kmr": "Karûbar",
       "ko": "서비스",
       "pt-BR": "Serviços",
-      "ru": "Services",
+      "ru": "Услуги",
       "so": "Adeegyada",
       "vi": "Dịch vụ",
       "zh-Hans": "服务",
-      "my": "Услуги"
+      "my": "ဝန်ဆောင်မှုများ"
     },
     "settings": {
       "ar": "الإعدادات",
@@ -2834,7 +2834,7 @@
     },
     "success": {
       "ar": "نجاح",
-      "en": "အောင်မြင်မှု",
+      "en": "Success",
       "es": "Éxito",
       "fil": "Tagumpay",
       "fr": "Succès",
@@ -2850,7 +2850,7 @@
     },
     "summary": {
       "ar": "الملخص",
-      "en": "အနှစ်ချုပ်",
+      "en": "Summary",
       "es": "Resumen",
       "fil": "Buod",
       "fr": "Résumé",
@@ -2858,7 +2858,7 @@
       "kmr": "Kurte",
       "ko": "요약",
       "pt-BR": "Resumo",
-      "ru": "Summary",
+      "ru": "Сводка",
       "so": "Soo Koob",
       "vi": "Tóm tắt",
       "zh-Hans": "摘要",
@@ -2866,7 +2866,7 @@
     },
     "support": {
       "ar": "الدعم",
-      "en": "ပံ့ပိုးမှု",
+      "en": "Support",
       "es": "Soporte",
       "fil": "Suporta",
       "fr": "Support",
@@ -2874,7 +2874,7 @@
       "kmr": "Piştgirî",
       "ko": "지원",
       "pt-BR": "Suporte",
-      "ru": "Support",
+      "ru": "Поддержка",
       "so": "Taageero",
       "vi": "Hỗ trợ",
       "zh-Hans": "支持",
@@ -2882,7 +2882,7 @@
     },
     "task": {
       "ar": "مهمة",
-      "en": "Задача",
+      "en": "Task",
       "es": "Tarea",
       "fil": "Gawain",
       "fr": "Tâche",
@@ -2890,15 +2890,15 @@
       "kmr": "Erk",
       "ko": "작업",
       "pt-BR": "Tarefa",
-      "ru": "Task",
+      "ru": "Задача",
       "so": "Hawl",
       "vi": "Nhiệm vụ",
       "zh-Hans": "任务",
-      "my": "Задача"
+      "my": "တာဝန်"
     },
     "tasks": {
       "ar": "المهام",
-      "en": "လုပ်ငန်းများ",
+      "en": "Tasks",
       "es": "Tareas",
       "fil": "Mga Gawain",
       "fr": "Tâches",
@@ -2906,7 +2906,7 @@
       "kmr": "Erk",
       "ko": "작업",
       "pt-BR": "Tarefas",
-      "ru": "Tasks",
+      "ru": "Задачи",
       "so": "Hawlaha",
       "vi": "Nhiệm vụ",
       "zh-Hans": "任务",
@@ -2914,7 +2914,7 @@
     },
     "time": {
       "ar": "الوقت",
-      "en": "အချိန်",
+      "en": "Time",
       "es": "Hora",
       "fil": "Oras",
       "fr": "Heure",
@@ -2922,7 +2922,7 @@
       "kmr": "Dem",
       "ko": "시간",
       "pt-BR": "Hora",
-      "ru": "Time",
+      "ru": "Время",
       "so": "Waqtiga",
       "vi": "Thời gian",
       "zh-Hans": "时间",
@@ -2930,7 +2930,7 @@
     },
     "title": {
       "ar": "العنوان",
-      "en": "ခေါင်းစဉ်",
+      "en": "Title",
       "es": "Título",
       "fil": "Pamagat",
       "fr": "Titre",
@@ -2938,7 +2938,7 @@
       "kmr": "Sernav",
       "ko": "제목",
       "pt-BR": "Título",
-      "ru": "Title",
+      "ru": "Заголовок",
       "so": "Cinwaanka",
       "vi": "Tiêu đề",
       "zh-Hans": "标题",
@@ -2946,7 +2946,7 @@
     },
     "total": {
       "ar": "المجموع",
-      "en": "စုစုပေါင်း",
+      "en": "Total",
       "es": "Total",
       "fil": "Kabuuan",
       "fr": "Total",
@@ -2954,7 +2954,7 @@
       "kmr": "Tevahî",
       "ko": "합계",
       "pt-BR": "Total",
-      "ru": "Total",
+      "ru": "Итого",
       "so": "Wadarta",
       "vi": "Tổng cộng",
       "zh-Hans": "总计",
@@ -2962,7 +2962,7 @@
     },
     "type": {
       "ar": "النوع",
-      "en": "Тип",
+      "en": "Type",
       "es": "Tipo",
       "fil": "Uri",
       "fr": "Type",
@@ -2970,15 +2970,15 @@
       "kmr": "Cure",
       "ko": "유형",
       "pt-BR": "Tipo",
-      "ru": "Type",
+      "ru": "Тип",
       "so": "Nooca",
       "vi": "Loại",
       "zh-Hans": "类型",
-      "my": "Тип"
+      "my": "အမျိုးအစား"
     },
     "unassigned": {
       "ar": "غير مسند",
-      "en": "Не Назначено",
+      "en": "Unassigned",
       "es": "Sin Asignar",
       "fil": "Walang Nakatakda",
       "fr": "Non Assigné",
@@ -2986,15 +2986,15 @@
       "kmr": "Nediyarkirî",
       "ko": "할당되지 않음",
       "pt-BR": "Não Atribuído",
-      "ru": "Unassigned",
+      "ru": "Не Назначено",
       "so": "Aan Loo Xilsaarin",
       "vi": "Chưa giao",
       "zh-Hans": "未分配",
-      "my": "Не Назначено"
+      "my": "မခန့်အပ်ရသေးပါ"
     },
     "update": {
       "ar": "تحديث",
-      "en": "Обновить",
+      "en": "Update",
       "es": "Actualizar",
       "fil": "I-update",
       "fr": "Mettre à Jour",
@@ -3002,15 +3002,15 @@
       "kmr": "Nûkirin",
       "ko": "업데이트",
       "pt-BR": "Atualizar",
-      "ru": "Update",
+      "ru": "Обновить",
       "so": "Cusboonaysii",
       "vi": "Cập nhật",
       "zh-Hans": "更新",
-      "my": "Обновить"
+      "my": "အပ်ဒိတ်လုပ်ပါ"
     },
     "updated": {
       "ar": "تم التحديث",
-      "en": "Обновлено",
+      "en": "Updated",
       "es": "Actualizado",
       "fil": "Na-update",
       "fr": "Mis à Jour",
@@ -3018,15 +3018,15 @@
       "kmr": "Hatiye Nûkirin",
       "ko": "업데이트됨",
       "pt-BR": "Atualizado",
-      "ru": "Updated",
+      "ru": "Обновлено",
       "so": "La Cusboonaysiiyay",
       "vi": "Đã cập nhật",
       "zh-Hans": "已更新",
-      "my": "Обновлено"
+      "my": "အပ်ဒိတ်လုပ်ပြီးပါပြီ"
     },
     "updated_at": {
       "ar": "تم التحديث في",
-      "en": "Обновлено",
+      "en": "Updated At",
       "es": "Actualizado el",
       "fil": "Na-update sa",
       "fr": "Mis à Jour le",
@@ -3034,15 +3034,15 @@
       "kmr": "Hatiye Nûkirin Li",
       "ko": "업데이트 일시",
       "pt-BR": "Atualizado em",
-      "ru": "Updated At",
+      "ru": "Обновлено",
       "so": "La Cusboonaysiiyay",
       "vi": "Cập nhật lúc",
       "zh-Hans": "更新于",
-      "my": "Обновлено"
+      "my": "နောက်ဆုံးအပ်ဒိတ်ချိန်"
     },
     "upload": {
       "ar": "رفع",
-      "en": "Загрузить",
+      "en": "Upload",
       "es": "Subir",
       "fil": "Mag-upload",
       "fr": "Téléverser",
@@ -3050,15 +3050,15 @@
       "kmr": "Barkirin",
       "ko": "업로드",
       "pt-BR": "Carregar",
-      "ru": "Upload",
+      "ru": "Загрузить",
       "so": "Soo Rar",
       "vi": "Tải lên",
       "zh-Hans": "上传",
-      "my": "Загрузить"
+      "my": "တင်ပါ"
     },
     "upload_document": {
       "ar": "رفع مستند",
-      "en": "Загрузить Документ",
+      "en": "Upload Document",
       "es": "Subir Documento",
       "fil": "Mag-upload ng Dokumento",
       "fr": "Téléverser un Document",
@@ -3066,15 +3066,15 @@
       "kmr": "Belgename Barbike",
       "ko": "문서 업로드",
       "pt-BR": "Carregar Documento",
-      "ru": "Upload Document",
+      "ru": "Загрузить Документ",
       "so": "Soo Rar Dukumeenti",
       "vi": "Tải lên Tài liệu",
       "zh-Hans": "上传文档",
-      "my": "Загрузить Документ"
+      "my": "စာရွက်စာတမ်းတင်ပါ"
     },
     "urgent": {
       "ar": "عاجل",
-      "en": "Срочный",
+      "en": "Urgent",
       "es": "Urgente",
       "fil": "Agarang",
       "fr": "Urgent",
@@ -3082,15 +3082,15 @@
       "kmr": "Lezgîn",
       "ko": "긴급",
       "pt-BR": "Urgente",
-      "ru": "Urgent",
+      "ru": "Срочный",
       "so": "Degdeg",
       "vi": "Khẩn cấp",
       "zh-Hans": "紧急",
-      "my": "Срочный"
+      "my": "အရေးပေါ်"
     },
     "user": {
       "ar": "المستخدم",
-      "en": "Пользователь",
+      "en": "User",
       "es": "Usuario",
       "fil": "User",
       "fr": "Utilisateur",
@@ -3098,15 +3098,15 @@
       "kmr": "Bikarhêner",
       "ko": "사용자",
       "pt-BR": "Usuário",
-      "ru": "User",
+      "ru": "Пользователь",
       "so": "Isticmaale",
       "vi": "Người dùng",
       "zh-Hans": "用户",
-      "my": "Пользователь"
+      "my": "အသုံးပြုသူ"
     },
     "user_details": {
       "ar": "تفاصيل المستخدم",
-      "en": "Детали Пользователя",
+      "en": "User Details",
       "es": "Detalles del Usuario",
       "fil": "Mga Detalye ng User",
       "fr": "Détails de l'Utilisateur",
@@ -3114,15 +3114,15 @@
       "kmr": "Hûrguliyên Bikarhêner",
       "ko": "사용자 세부정보",
       "pt-BR": "Detalhes do Usuário",
-      "ru": "User Details",
+      "ru": "Детали Пользователя",
       "so": "Faahfaahinta Isticmaalaha",
       "vi": "Chi tiết Người dùng",
       "zh-Hans": "用户详情",
-      "my": "Детали Пользователя"
+      "my": "အသုံးပြုသူအချက်အလက်များ"
     },
     "user_management": {
       "ar": "إدارة المستخدمين",
-      "en": "Управление Пользователями",
+      "en": "User Management",
       "es": "Gestión de Usuarios",
       "fil": "Pamamahala ng User",
       "fr": "Gestion des Utilisateurs",
@@ -3130,15 +3130,15 @@
       "kmr": "Rêvebirina Bikarhêneran",
       "ko": "사용자 관리",
       "pt-BR": "Gerenciamento de Usuários",
-      "ru": "User Management",
+      "ru": "Управление Пользователями",
       "so": "Maaraynta Isticmaalayaasha",
       "vi": "Quản lý Người dùng",
       "zh-Hans": "用户管理",
-      "my": "Управление Пользователями"
+      "my": "အသုံးပြုသူစီမံခန့်ခွဲမှု"
     },
     "username": {
       "ar": "اسم المستخدم",
-      "en": "Имя Пользователя",
+      "en": "Username",
       "es": "Nombre de Usuario",
       "fil": "Username",
       "fr": "Nom d'Utilisateur",
@@ -3146,15 +3146,15 @@
       "kmr": "Navê Bikarhêner",
       "ko": "사용자 이름",
       "pt-BR": "Nome de Usuário",
-      "ru": "Username",
+      "ru": "Имя Пользователя",
       "so": "Magaca Isticmaalaha",
       "vi": "Tên người dùng",
       "zh-Hans": "用户名",
-      "my": "Имя Пользователя"
+      "my": "အသုံးပြုသူအမည်"
     },
     "users": {
       "ar": "المستخدمون",
-      "en": "Пользователи",
+      "en": "Users",
       "es": "Usuarios",
       "fil": "Mga User",
       "fr": "Utilisateurs",
@@ -3162,15 +3162,15 @@
       "kmr": "Bikarhêner",
       "ko": "사용자",
       "pt-BR": "Usuários",
-      "ru": "Users",
+      "ru": "Пользователи",
       "so": "Isticmaalayaasha",
       "vi": "Người dùng",
       "zh-Hans": "用户",
-      "my": "Пользователи"
+      "my": "အသုံးပြုသူများ"
     },
     "view": {
       "ar": "عرض",
-      "en": "Просмотр",
+      "en": "View",
       "es": "Ver",
       "fil": "Tingnan",
       "fr": "Voir",
@@ -3178,15 +3178,15 @@
       "kmr": "Nîşan Bide",
       "ko": "보기",
       "pt-BR": "Ver",
-      "ru": "View",
+      "ru": "Просмотр",
       "so": "Arag",
       "vi": "Xem",
       "zh-Hans": "查看",
-      "my": "Просмотр"
+      "my": "ကြည့်ရှုပါ"
     },
     "view_all": {
       "ar": "عرض الكل",
-      "en": "Посмотреть Все",
+      "en": "View All",
       "es": "Ver Todo",
       "fil": "Tingnan Lahat",
       "fr": "Tout Voir",
@@ -3194,15 +3194,15 @@
       "kmr": "Hemû Bibîne",
       "ko": "전체 보기",
       "pt-BR": "Ver Todos",
-      "ru": "View All",
+      "ru": "Посмотреть Все",
       "so": "Arag Dhammaan",
       "vi": "Xem Tất cả",
       "zh-Hans": "查看全部",
-      "my": "Посмотреть Все"
+      "my": "အားလုံးကို ကြည့်ရှုပါ"
     },
     "view_details": {
       "ar": "عرض التفاصيل",
-      "en": "Просмотреть Детали",
+      "en": "View Details",
       "es": "Ver Detalles",
       "fil": "Tingnan ang mga Detalye",
       "fr": "Voir les Détails",
@@ -3210,15 +3210,15 @@
       "kmr": "Hûrguliyan Bibîne",
       "ko": "세부정보 보기",
       "pt-BR": "Ver Detalhes",
-      "ru": "View Details",
+      "ru": "Просмотреть Детали",
       "so": "Arag Faahfaahinta",
       "vi": "Xem Chi tiết",
       "zh-Hans": "查看详情",
-      "my": "Просмотреть Детали"
+      "my": "အသေးစိတ်ကြည့်ရှုပါ"
     },
     "welcome": {
       "ar": "مرحباً",
-      "en": "Добро Пожаловать",
+      "en": "Welcome",
       "es": "Bienvenido",
       "fil": "Maligayang Pagdating",
       "fr": "Bienvenue",
@@ -3226,15 +3226,15 @@
       "kmr": "Bi Xêr Hatî",
       "ko": "환영합니다",
       "pt-BR": "Bem-vindo",
-      "ru": "Welcome",
+      "ru": "Добро Пожаловать",
       "so": "Soo Dhowow",
       "vi": "Chào mừng",
       "zh-Hans": "欢迎",
-      "my": "Добро Пожаловать"
+      "my": "ကြိုဆိုပါသည်"
     },
     "yes": {
       "ar": "نعم",
-      "en": "Да",
+      "en": "Yes",
       "es": "Sí",
       "fil": "Oo",
       "fr": "Oui",
@@ -3242,15 +3242,15 @@
       "kmr": "Erê",
       "ko": "예",
       "pt-BR": "Sim",
-      "ru": "Yes",
+      "ru": "Да",
       "so": "Haa",
       "vi": "Có",
       "zh-Hans": "是",
-      "my": "Да"
+      "my": "ဟုတ်ကဲ့"
     },
     "zip_code": {
       "ar": "الرمز البريدي",
-      "en": "Почтовый Индекс",
+      "en": "ZIP Code",
       "es": "Código Postal",
       "fil": "ZIP Code",
       "fr": "Code Postal",
@@ -3258,11 +3258,11 @@
       "kmr": "Koda Postê",
       "ko": "우편번호",
       "pt-BR": "CEP",
-      "ru": "ZIP Code",
+      "ru": "Почтовый Индекс",
       "so": "Koodka Boostada",
       "vi": "Mã ZIP",
       "zh-Hans": "邮政编码",
-      "my": "Почтовый Индекс"
+      "my": "စာပို့ကုဒ်"
     }
   },
   "personal_health_vault": {


### PR DESCRIPTION
## Summary
- realign the English, Russian, and Burmese strings for the care_connect labels so each locale shows the correct language

## Testing
- browser_container.run_playwright_script (locale verification script)


------
https://chatgpt.com/codex/tasks/task_b_68e3e7d3b98c8332b37b6a5397bbd795