### PR TITLE
Adjust navigation tabs layout for wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             color: #1e293b;
             background: white;
             padding: 20px;
-            padding-top: 105px;
+            padding-top: 160px;
         }
         
         .unlock-screen {
@@ -491,9 +491,10 @@
             background: #f8fafc;
             border-bottom: 1px solid #e2e8f0;
             z-index: 999;
-            overflow-x: auto;
-            white-space: nowrap;
-            padding: 0 20px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px 12px;
+            padding: 8px 20px;
             scrollbar-width: thin;
         }
         
@@ -507,7 +508,9 @@
         }
         
         .tab {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
             padding: 12px 20px;
             cursor: pointer;
             border-bottom: 3px solid transparent;
@@ -515,6 +518,8 @@
             font-size: 10pt;
             font-weight: 500;
             color: #64748b;
+            flex: 0 1 auto;
+            min-width: 0;
         }
         
         .tab:hover {
@@ -1501,7 +1506,7 @@
         @media (max-width: 900px) {
             body {
                 padding: 15px;
-                padding-top: 150px;
+                padding-top: 200px;
                 font-size: 10.5pt;
             }
 
@@ -1565,8 +1570,8 @@
             }
 
             .nav-tabs {
-                top: 68px;
-                padding: 0 12px;
+                top: 88px;
+                padding: 8px 12px;
             }
 
             .tab {
@@ -1623,52 +1628,6 @@
             }
         }
 
-        @media (max-width: 600px) {
-            body {
-                padding: 12px;
-                padding-top: 170px;
-            }
-
-            .unlock-container {
-                width: 100%;
-            }
-
-            .security-bar {
-                gap: 12px;
-            }
-
-            .security-status {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 4px;
-            }
-
-            .action-buttons {
-                gap: 8px;
-            }
-
-            .action-buttons .btn {
-                flex: 1 1 100%;
-                min-width: 0;
-            }
-
-            .main-content {
-                margin-top: 10px;
-            }
-
-            .vitals-grid {
-                grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-            }
-
-            .modal-header h2 {
-                font-size: 16pt;
-            }
-
-            .modal {
-                align-items: flex-start;
-            }
-        }
-        
         .totp-setup {
             text-align: center;
             padding: 20px;
@@ -1903,20 +1862,20 @@
             .grid-3 {
                 grid-template-columns: 1fr;
             }
-            
+
             .field-row {
                 flex-direction: column;
                 gap: 0;
             }
-            
+
             body {
                 padding: 10px;
-                padding-top: 140px;
+                padding-top: 210px;
             }
-            
+
             .nav-tabs {
-                padding: 0 10px;
-                top: 100px;
+                padding: 8px 10px;
+                top: 130px;
             }
             
             .tab {
@@ -1942,7 +1901,53 @@
                 width: 100%;
             }
         }
-        
+
+        @media (max-width: 600px) {
+            body {
+                padding: 12px;
+                padding-top: 230px;
+            }
+
+            .unlock-container {
+                width: 100%;
+            }
+
+            .security-bar {
+                gap: 12px;
+            }
+
+            .security-status {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 4px;
+            }
+
+            .action-buttons {
+                gap: 8px;
+            }
+
+            .action-buttons .btn {
+                flex: 1 1 100%;
+                min-width: 0;
+            }
+
+            .main-content {
+                margin-top: 10px;
+            }
+
+            .vitals-grid {
+                grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            }
+
+            .modal-header h2 {
+                font-size: 16pt;
+            }
+
+            .modal {
+                align-items: flex-start;
+            }
+        }
+
         .hidden {
             display: none !important;
         }


### PR DESCRIPTION
## Summary
- update the navigation tabs container to use a wrapping flex layout instead of horizontal scrolling
- tweak tab styling so items behave as flex children while preserving their interactive states
- increase global and responsive body offsets so the fixed navigation no longer overlaps content when it wraps

## Testing
- Manual verification of navigation layout at a 1280px viewport

------
https://chatgpt.com/codex/tasks/task_b_68e3eac11d188332b30f426dd19f4f87