### PR TITLE
Restrict localization to English and Spanish

### DIFF
--- a/index.html
+++ b/index.html
@@ -2861,77 +2861,78 @@
         <!-- Gender Affirming Care Module (Hidden by default) -->
         <div class="section module-section" id="gac-section" style="display: none;">
             <div class="section-header module">
-                <h2>🏳️‍⚧️ Gender Affirming Care</h2>
+                <h2 data-i18n-key="gac_section_title">🏳️‍⚧️ Gender Affirming Care</h2>
             </div>
             <div class="section-content">
-                <h3>Hormone Therapy</h3>
+                <h3 data-i18n-key="gac_hormone_heading">Hormone Therapy</h3>
                 <div class="grid-2">
                     <div class="field">
-                        <label>HRT Status</label>
+                        <label data-i18n-key="hrt_status_label">HRT Status</label>
                         <select class="form-data" data-field="hrtStatus">
-                            <option value="">Select...</option>
-                            <option>Not Started</option>
-                            <option>Active</option>
-                            <option>Paused</option>
-                            <option>Discontinued</option>
+                            <option value="" data-i18n-key="option_select_placeholder">Select...</option>
+                            <option data-i18n-key="hrt_status_option_not_started">Not Started</option>
+                            <option data-i18n-key="hrt_status_option_active">Active</option>
+                            <option data-i18n-key="hrt_status_option_paused">Paused</option>
+                            <option data-i18n-key="hrt_status_option_discontinued">Discontinued</option>
                         </select>
                     </div>
                     <div class="field">
-                        <label>HRT Start Date</label>
+                        <label data-i18n-key="hrt_start_date_label">HRT Start Date</label>
                         <input type="date" class="form-data" data-field="hrtStartDate" />
                     </div>
                 </div>
                 
                 <div class="field">
-                    <label>Current Hormone Regimen</label>
+                    <label data-i18n-key="current_hormone_regimen_label">Current Hormone Regimen</label>
                     <textarea rows="3" class="form-data" data-field="hormoneRegimen"></textarea>
                 </div>
                 
-                <h3>Gender-Affirming Procedures</h3>
+                <h3 data-i18n-key="gac_procedures_heading">Gender-Affirming Procedures</h3>
                 <div id="gac-procedures-container"></div>
-                <button class="add-btn no-print" id="addGACProcedureBtn">+ Add Procedure</button>
+                <button class="add-btn no-print" id="addGACProcedureBtn" data-i18n-key="add_procedure_button">+ Add Procedure</button>
 
-                <h3>Gender-Affirming Care Notes</h3>
+                <h3 data-i18n-key="gac_notes_heading">Gender-Affirming Care Notes</h3>
                 <div class="info-box">
-                    Track care plans, provider feedback, goals, and milestones that are specific to gender-affirming care. Each note supports optional event dates, provider tagging, and reusable tags for quick filtering.
+                    <p data-i18n-key="gac_notes_info_line1">Track care plans, provider feedback, goals, and milestones that are specific to gender-affirming care.</p>
+                    <p data-i18n-key="gac_notes_info_line2">Each note supports optional event dates, provider tagging, and reusable tags for quick filtering.</p>
                 </div>
                 <div id="gac-notes-container"></div>
-                <button class="add-btn no-print" id="addGACNoteBtn">+ Add GAC Note</button>
+                <button class="add-btn no-print" id="addGACNoteBtn" data-i18n-key="add_gac_note_button">+ Add GAC Note</button>
             </div>
         </div>
 
         <!-- Mental Health Module (Hidden by default) -->
         <div class="section module-section" id="mental-section" style="display: none;">
             <div class="section-header module">
-                <h2>🧠 Mental Health</h2>
+                <h2 data-i18n-key="mental_section_title">🧠 Mental Health</h2>
             </div>
             
             <div class="section-content">
-                <h3>Current Mental Health</h3>
+                <h3 data-i18n-key="mental_current_heading">Current Mental Health</h3>
                 <div class="field">
-                    <label>Diagnoses</label>
+                    <label data-i18n-key="mental_diagnoses_label">Diagnoses</label>
                     <textarea rows="2" class="form-data" data-field="mentalDiagnoses"></textarea>
                 </div>
-                
+
                 <div class="grid-2">
                     <div class="field">
-                        <label>Therapist/Counselor</label>
+                        <label data-i18n-key="therapist_label">Therapist/Counselor</label>
                         <input type="text" class="form-data" data-field="therapist" />
                     </div>
                     <div class="field">
-                        <label>Psychiatrist</label>
+                        <label data-i18n-key="psychiatrist_label">Psychiatrist</label>
                         <input type="text" class="form-data" data-field="psychiatrist" />
                     </div>
                 </div>
-                
-                <h3>Crisis Resources</h3>
+
+                <h3 data-i18n-key="mental_crisis_heading">Crisis Resources</h3>
                 <div class="field">
-                    <label>Crisis Contacts</label>
-                    <textarea rows="3" class="form-data" data-field="crisisContacts" placeholder="988 Suicide & Crisis Lifeline&#10;Crisis text line: Text HOME to 741741"></textarea>
+                    <label data-i18n-key="crisis_contacts_label">Crisis Contacts</label>
+                    <textarea rows="3" class="form-data" data-field="crisisContacts" data-i18n-placeholder="crisis_contacts_placeholder" placeholder="988 Suicide &amp; Crisis Lifeline&#10;Crisis text line: Text HOME to 741741"></textarea>
                 </div>
-                
+
                 <div class="field">
-                    <label>Safety Plan</label>
+                    <label data-i18n-key="safety_plan_label">Safety Plan</label>
                     <textarea rows="4" class="form-data" data-field="safetyPlan"></textarea>
                 </div>
             </div>
@@ -2940,47 +2941,47 @@
         <!-- Chronic Disease Module (Hidden by default) -->
         <div class="section module-section" id="chronic-section" style="display: none;">
             <div class="section-header module">
-                <h2>📊 Chronic Disease Management</h2>
+                <h2 data-i18n-key="chronic_section_title">📊 Chronic Disease Management</h2>
             </div>
             <div class="section-content">
-                <h3>Diabetes Management</h3>
+                <h3 data-i18n-key="diabetes_management_heading">Diabetes Management</h3>
                 <div class="checkbox-item">
                     <input type="checkbox" id="has-diabetes" class="form-data" data-field="hasDiabetes">
-                    <label for="has-diabetes">I have diabetes</label>
+                    <label for="has-diabetes" data-i18n-key="have_diabetes_label">I have diabetes</label>
                 </div>
-                
+
                 <div id="diabetesFields" style="display: none; margin-top: 15px;">
                     <div class="grid-3">
                         <div class="field">
-                            <label>Type</label>
+                            <label data-i18n-key="diabetes_type_label">Type</label>
                             <select class="form-data" data-field="diabetesType">
-                                <option value="">Select...</option>
-                                <option>Type 1</option>
-                                <option>Type 2</option>
-                                <option>Gestational</option>
-                                <option>Other</option>
+                                <option value="" data-i18n-key="option_select_placeholder">Select...</option>
+                                <option data-i18n-key="diabetes_type_option_1">Type 1</option>
+                                <option data-i18n-key="diabetes_type_option_2">Type 2</option>
+                                <option data-i18n-key="diabetes_type_option_gestational">Gestational</option>
+                                <option data-i18n-key="diabetes_type_option_other">Other</option>
                             </select>
                         </div>
                         <div class="field">
-                            <label>Last A1C</label>
+                            <label data-i18n-key="last_a1c_label">Last A1C</label>
                             <input type="text" class="form-data" data-field="lastA1c" placeholder="7.2" />
                         </div>
                         <div class="field">
-                            <label>A1C Date</label>
+                            <label data-i18n-key="a1c_date_label">A1C Date</label>
                             <input type="date" class="form-data" data-field="a1cDate" />
                         </div>
                     </div>
                 </div>
-                
-                <h3>Blood Pressure Management</h3>
+
+                <h3 data-i18n-key="blood_pressure_management_heading">Blood Pressure Management</h3>
                 <div class="checkbox-item">
                     <input type="checkbox" id="has-hypertension" class="form-data" data-field="hasHypertension">
-                    <label for="has-hypertension">I have hypertension</label>
+                    <label for="has-hypertension" data-i18n-key="have_hypertension_label">I have hypertension</label>
                 </div>
-                
+
                 <div id="hypertensionFields" style="display: none; margin-top: 15px;">
                     <div class="field">
-                        <label>Target Blood Pressure</label>
+                        <label data-i18n-key="target_bp_label">Target Blood Pressure</label>
                         <input type="text" class="form-data" data-field="targetBP" placeholder="< 130/80" />
                     </div>
                 </div>
@@ -2988,9 +2989,9 @@
         </div>
 
     <div class="info-box" style="margin-top: 30px;">
-        <strong>Important:</strong> This vault file (.ehv) contains all your encrypted medical data.
-        After making changes, click "Download Updated Vault (.ehv)" to save the new file.
-        Replace your old file with the new one. Keep backups in secure locations.
+        <strong data-i18n-key="important_notice">Important:</strong> <span data-i18n-key="final_info_line1">This vault file (.ehv) contains all your encrypted medical data.</span>
+        <span data-i18n-key="final_info_line2">After making changes, click "Download Updated Vault (.ehv)" to save the new file.</span>
+        <span data-i18n-key="final_info_line3">Replace your old file with the new one. Keep backups in secure locations.</span>
     </div>
     </div>
 
@@ -3288,6 +3289,7 @@
                 this.languageSelectors = [];
                 this.currentLanguage = 'en';
                 this.fallbackLanguage = 'en';
+                this.allowedLanguages = ['en', 'es'];
             }
 
             async init() {
@@ -3323,6 +3325,13 @@
 
                 if (!this.translations || typeof this.translations !== 'object') {
                     this.translations = { en: {} };
+                }
+
+                if (Array.isArray(this.allowedLanguages) && this.allowedLanguages.length) {
+                    this.translations = Object.fromEntries(
+                        Object.entries(this.translations)
+                            .filter(([lang]) => this.allowedLanguages.includes(lang))
+                    );
                 }
 
                 if (!this.translations.en) {
@@ -3379,8 +3388,26 @@
                     return { en: {} };
                 }
 
+                const allowedLanguageSet = Array.isArray(this.allowedLanguages) && this.allowedLanguages.length
+                    ? new Set(this.allowedLanguages)
+                    : null;
+
                 if (raw.en && typeof raw.en === 'object' && !Array.isArray(raw.en)) {
-                    return raw;
+                    if (!allowedLanguageSet) {
+                        return raw;
+                    }
+                    const filtered = {};
+                    const languages = Object.keys(raw).filter(lang => allowedLanguageSet.has(lang));
+                    if (!languages.length) {
+                        return { en: raw.en };
+                    }
+                    languages.forEach(lang => {
+                        filtered[lang] = raw[lang] || {};
+                    });
+                    if (!filtered.en) {
+                        filtered.en = {};
+                    }
+                    return filtered;
                 }
 
                 const languageKeyPattern = /^[a-z]{2,3}(?:-[A-Za-z]{2,4})?$/;
@@ -3409,8 +3436,17 @@
                     return { en: {} };
                 }
 
+                const filteredLanguages = allowedLanguageSet
+                    ? Array.from(languageSet).filter(lang => allowedLanguageSet.has(lang))
+                    : Array.from(languageSet);
+
+                if (!filteredLanguages.length) {
+                    return { en: {} };
+                }
+
+                const filteredLanguageSet = new Set(filteredLanguages);
                 const result = {};
-                languageSet.forEach(lang => {
+                filteredLanguages.forEach(lang => {
                     result[lang] = {};
                 });
 
@@ -3429,12 +3465,14 @@
                         if (!translationKey) {
                             return;
                         }
-                        keys.forEach(lang => {
-                            if (!result[lang]) {
-                                result[lang] = {};
-                            }
-                            result[lang][translationKey] = node[lang];
-                        });
+                        keys
+                            .filter(lang => filteredLanguageSet.has(lang))
+                            .forEach(lang => {
+                                if (!result[lang]) {
+                                    result[lang] = {};
+                                }
+                                result[lang][translationKey] = node[lang];
+                            });
                         return;
                     }
                     keys.forEach(key => assignTranslations(node[key], [...path, key]));

--- a/translations.json
+++ b/translations.json
@@ -4818,5 +4818,169 @@
       "vi": "This vault file (.ehv) will contain your encrypted data. Always download and save the updated .ehv file after making changes.",
       "zh-Hans": "This vault file (.ehv) will contain your encrypted data. Always download and save the updated .ehv file after making changes."
     }
+  },
+  "gac_section_title": {
+    "en": "🏳️‍⚧️ Gender Affirming Care",
+    "es": "🏳️‍⚧️ Atención de afirmación de género"
+  },
+  "gac_hormone_heading": {
+    "en": "Hormone Therapy",
+    "es": "Terapia hormonal"
+  },
+  "hrt_status_label": {
+    "en": "HRT Status",
+    "es": "Estado de la TRH"
+  },
+  "option_select_placeholder": {
+    "en": "Select...",
+    "es": "Selecciona..."
+  },
+  "hrt_status_option_not_started": {
+    "en": "Not Started",
+    "es": "No iniciada"
+  },
+  "hrt_status_option_active": {
+    "en": "Active",
+    "es": "Activa"
+  },
+  "hrt_status_option_paused": {
+    "en": "Paused",
+    "es": "En pausa"
+  },
+  "hrt_status_option_discontinued": {
+    "en": "Discontinued",
+    "es": "Interrumpida"
+  },
+  "hrt_start_date_label": {
+    "en": "HRT Start Date",
+    "es": "Fecha de inicio de la TRH"
+  },
+  "current_hormone_regimen_label": {
+    "en": "Current Hormone Regimen",
+    "es": "Régimen hormonal actual"
+  },
+  "gac_procedures_heading": {
+    "en": "Gender-Affirming Procedures",
+    "es": "Procedimientos de afirmación de género"
+  },
+  "add_procedure_button": {
+    "en": "+ Add Procedure",
+    "es": "+ Agregar procedimiento"
+  },
+  "gac_notes_heading": {
+    "en": "Gender-Affirming Care Notes",
+    "es": "Notas de atención de afirmación de género"
+  },
+  "gac_notes_info_line1": {
+    "en": "Track care plans, provider feedback, goals, and milestones that are specific to gender-affirming care.",
+    "es": "Registra planes de atención, comentarios de proveedores, objetivos y hitos específicos del cuidado de afirmación de género."
+  },
+  "gac_notes_info_line2": {
+    "en": "Each note supports optional event dates, provider tagging, and reusable tags for quick filtering.",
+    "es": "Cada nota admite fechas opcionales, etiquetas de proveedores y etiquetas reutilizables para un filtrado rápido."
+  },
+  "add_gac_note_button": {
+    "en": "+ Add GAC Note",
+    "es": "+ Agregar nota de AAG"
+  },
+  "mental_section_title": {
+    "en": "🧠 Mental Health",
+    "es": "🧠 Salud mental"
+  },
+  "mental_current_heading": {
+    "en": "Current Mental Health",
+    "es": "Salud mental actual"
+  },
+  "mental_diagnoses_label": {
+    "en": "Diagnoses",
+    "es": "Diagnósticos"
+  },
+  "therapist_label": {
+    "en": "Therapist/Counselor",
+    "es": "Terapeuta/Consejero"
+  },
+  "psychiatrist_label": {
+    "en": "Psychiatrist",
+    "es": "Psiquiatra"
+  },
+  "mental_crisis_heading": {
+    "en": "Crisis Resources",
+    "es": "Recursos de crisis"
+  },
+  "crisis_contacts_label": {
+    "en": "Crisis Contacts",
+    "es": "Contactos de crisis"
+  },
+  "crisis_contacts_placeholder": {
+    "en": "988 Suicide & Crisis Lifeline\nCrisis text line: Text HOME to 741741",
+    "es": "Línea 988 de suicidio y crisis\nLínea de texto para crisis: envía HOME al 741741"
+  },
+  "safety_plan_label": {
+    "en": "Safety Plan",
+    "es": "Plan de seguridad"
+  },
+  "chronic_section_title": {
+    "en": "📊 Chronic Disease Management",
+    "es": "📊 Manejo de enfermedades crónicas"
+  },
+  "diabetes_management_heading": {
+    "en": "Diabetes Management",
+    "es": "Manejo de la diabetes"
+  },
+  "have_diabetes_label": {
+    "en": "I have diabetes",
+    "es": "Tengo diabetes"
+  },
+  "diabetes_type_label": {
+    "en": "Type",
+    "es": "Tipo"
+  },
+  "diabetes_type_option_1": {
+    "en": "Type 1",
+    "es": "Tipo 1"
+  },
+  "diabetes_type_option_2": {
+    "en": "Type 2",
+    "es": "Tipo 2"
+  },
+  "diabetes_type_option_gestational": {
+    "en": "Gestational",
+    "es": "Gestacional"
+  },
+  "diabetes_type_option_other": {
+    "en": "Other",
+    "es": "Otro"
+  },
+  "last_a1c_label": {
+    "en": "Last A1C",
+    "es": "Último A1C"
+  },
+  "a1c_date_label": {
+    "en": "A1C Date",
+    "es": "Fecha de A1C"
+  },
+  "blood_pressure_management_heading": {
+    "en": "Blood Pressure Management",
+    "es": "Manejo de la presión arterial"
+  },
+  "have_hypertension_label": {
+    "en": "I have hypertension",
+    "es": "Tengo hipertensión"
+  },
+  "target_bp_label": {
+    "en": "Target Blood Pressure",
+    "es": "Presión arterial objetivo"
+  },
+  "final_info_line1": {
+    "en": "This vault file (.ehv) contains all your encrypted medical data.",
+    "es": "Este archivo de bóveda (.ehv) contiene todos tus datos médicos cifrados."
+  },
+  "final_info_line2": {
+    "en": "After making changes, click \"Download Updated Vault (.ehv)\" to save the new file.",
+    "es": "Después de realizar cambios, haz clic en \"Descargar bóveda actualizada (.ehv)\" para guardar el nuevo archivo."
+  },
+  "final_info_line3": {
+    "en": "Replace your old file with the new one. Keep backups in secure locations.",
+    "es": "Reemplaza tu archivo anterior con el nuevo. Conserva copias de seguridad en lugares seguros."
   }
 }


### PR DESCRIPTION
## Summary
- limit the localization manager to English and Spanish by filtering loaded translations and selector options
- add translation hooks and English/Spanish copy for the gender-affirming care, mental health, and chronic disease modules plus the footer notice

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e3ebbf86088332bfaba968d2ce97ed