### PR TITLE
Improve Spanish localization of welcome screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2335,25 +2335,26 @@
 
     <!-- Welcome Screen (shown for new files) -->
     <div class="welcome-screen" id="welcomeScreen" style="display: none;">
-        <h1>🏥 Personal Health Vault</h1>
+        <h1 data-i18n-key="welcome_screen_title">🏥 Personal Health Vault</h1>
         <p>
-            Welcome to your secure, self-contained medical record system.
-            This single .ehv vault file will become your encrypted health vault.
+            <span data-i18n-key="welcome_screen_intro_line1">Welcome to your secure, self-contained medical record system.</span>
+            <br>
+            <span data-i18n-key="welcome_screen_intro_line2">This single .ehv vault file will become your encrypted health vault.</span>
         </p>
         <div class="info-box" style="text-align: left;">
-            <strong>How it works:</strong>
+            <strong data-i18n-key="welcome_screen_how_it_works">How it works:</strong>
             <ul style="margin-top: 10px; margin-left: 20px;">
-                <li>All data is encrypted with your password</li>
-                <li>This .ehv vault file contains everything - no separate data files</li>
-                <li>Works offline, no internet required</li>
-                <li>Your data never leaves your device</li>
+                <li data-i18n-key="welcome_screen_bullet_encrypted">All data is encrypted with your password</li>
+                <li data-i18n-key="welcome_screen_bullet_contains_all">This .ehv vault file contains everything - no separate data files</li>
+                <li data-i18n-key="welcome_screen_bullet_offline">Works offline, no internet required</li>
+                <li data-i18n-key="welcome_screen_bullet_data_local">Your data never leaves your device</li>
             </ul>
         </div>
         <div class="welcome-actions">
-            <button class="btn-start" onclick="app?.startSetup()">
+            <button class="btn-start" onclick="app?.startSetup()" data-i18n-key="welcome_screen_get_started">
                 Get Started
             </button>
-            <button class="btn-import" id="openVaultBtn">
+            <button class="btn-import" id="openVaultBtn" data-i18n-key="welcome_screen_open_existing">
                 Open Existing Vault
             </button>
         </div>

--- a/translations.json
+++ b/translations.json
@@ -3232,6 +3232,46 @@
       "zh-Hans": "欢迎",
       "my": "ကြိုဆိုပါသည်"
     },
+    "welcome_screen_title": {
+      "en": "🏥 Personal Health Vault",
+      "es": "🏥 Bóveda de Salud Personal"
+    },
+    "welcome_screen_intro_line1": {
+      "en": "Welcome to your secure, self-contained medical record system.",
+      "es": "Bienvenido a tu sistema de historial médico seguro e independiente."
+    },
+    "welcome_screen_intro_line2": {
+      "en": "This single .ehv vault file will become your encrypted health vault.",
+      "es": "Este único archivo de bóveda .ehv se convertirá en tu bóveda de salud cifrada."
+    },
+    "welcome_screen_how_it_works": {
+      "en": "How it works:",
+      "es": "Cómo funciona:"
+    },
+    "welcome_screen_bullet_encrypted": {
+      "en": "All data is encrypted with your password",
+      "es": "Todos los datos se cifran con tu contraseña"
+    },
+    "welcome_screen_bullet_contains_all": {
+      "en": "This .ehv vault file contains everything - no separate data files",
+      "es": "Este archivo de bóveda .ehv contiene todo; no hay archivos de datos separados"
+    },
+    "welcome_screen_bullet_offline": {
+      "en": "Works offline, no internet required",
+      "es": "Funciona sin conexión; no se necesita internet"
+    },
+    "welcome_screen_bullet_data_local": {
+      "en": "Your data never leaves your device",
+      "es": "Tus datos nunca salen de tu dispositivo"
+    },
+    "welcome_screen_get_started": {
+      "en": "Get Started",
+      "es": "Comenzar"
+    },
+    "welcome_screen_open_existing": {
+      "en": "Open Existing Vault",
+      "es": "Abrir bóveda existente"
+    },
     "yes": {
       "ar": "نعم",
       "en": "Yes",


### PR DESCRIPTION
## Summary
- add localization hooks to the welcome screen elements
- provide Spanish translations for the welcome screen copy

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e40477ce14833288e052971b5b0197