### PR TITLE
Store attachment payloads as byte arrays

### DIFF
--- a/index.html
+++ b/index.html
@@ -6693,10 +6693,19 @@
                                 : (typeof file.size === 'number' ? file.size : 0),
                             compressedSize: typeof result?.compressedSize === 'number'
                                 ? result.compressedSize
-                                : (typeof result?.data === 'string' ? Math.ceil(result.data.length * 3 / 4) : (typeof file.size === 'number' ? file.size : 0)),
-                            data: typeof result?.data === 'string' ? result.data : ''
+                                : (Array.isArray(result?.data)
+                                    ? result.data.length
+                                    : (typeof result?.data === 'string'
+                                        ? Math.ceil(result.data.length * 3 / 4)
+                                        : (typeof file.size === 'number' ? file.size : 0))),
+                            data: Array.isArray(result?.data)
+                                ? result.data.slice()
+                                : (typeof result?.data === 'string' ? result.data : '')
                         };
-                        if (!attachment.data) {
+                        const hasData = Array.isArray(attachment.data)
+                            ? attachment.data.length > 0
+                            : (typeof attachment.data === 'string' ? attachment.data.trim() !== '' : false);
+                        if (!hasData) {
                             throw new Error('Attachment data is empty');
                         }
                         this.attachments.push(attachment);
@@ -6773,15 +6782,8 @@
                                     }
                                 }
 
-                                const chunkSize = 0x8000;
-                                let binary = '';
-                                for (let i = 0; i < finalBytes.length; i += chunkSize) {
-                                    const chunk = finalBytes.subarray(i, i + chunkSize);
-                                    binary += String.fromCharCode(...chunk);
-                                }
-
                                 resolve({
-                                    data: btoa(binary),
+                                    data: Array.from(finalBytes),
                                     compressed: isCompressed,
                                     originalSize: bytes.length,
                                     compressedSize: finalBytes.length
@@ -6789,11 +6791,20 @@
                             } else if (typeof result === 'string') {
                                 const base64Match = result.match(/^data:[^;]+;base64,(.*)$/);
                                 const data = base64Match ? base64Match[1] : result;
+                                const clean = typeof data === 'string' ? data.trim() : '';
+                                let decodedBytes = new Uint8Array(0);
+                                if (clean) {
+                                    const binary = atob(clean);
+                                    decodedBytes = new Uint8Array(binary.length);
+                                    for (let i = 0; i < binary.length; i++) {
+                                        decodedBytes[i] = binary.charCodeAt(i);
+                                    }
+                                }
                                 resolve({
-                                    data,
+                                    data: Array.from(decodedBytes),
                                     compressed: false,
                                     originalSize: typeof file.size === 'number' ? file.size : 0,
-                                    compressedSize: typeof file.size === 'number' ? file.size : 0
+                                    compressedSize: decodedBytes.length || (typeof file.size === 'number' ? file.size : 0)
                                 });
                             } else {
                                 reject(new Error('Unsupported file data'));
@@ -6937,10 +6948,18 @@
                         size: attachment.size,
                         compressed: !!attachment.compressed,
                         originalSize: typeof attachment.originalSize === 'number' ? attachment.originalSize : (typeof attachment.size === 'number' ? attachment.size : 0),
-                        compressedSize: typeof attachment.compressedSize === 'number' ? attachment.compressedSize : (typeof attachment.data === 'string' ? Math.ceil(attachment.data.length * 3 / 4) : (typeof attachment.size === 'number' ? attachment.size : 0)),
+                        compressedSize: typeof attachment.compressedSize === 'number'
+                            ? attachment.compressedSize
+                            : (Array.isArray(attachment.data)
+                                ? attachment.data.length
+                                : (typeof attachment.data === 'string'
+                                    ? Math.ceil(attachment.data.length * 3 / 4)
+                                    : (typeof attachment.size === 'number' ? attachment.size : 0))),
                         lastModified: attachment.lastModified,
                         addedAt: attachment.addedAt,
-                        data: typeof attachment.data === 'string' ? attachment.data : ''
+                        data: Array.isArray(attachment.data)
+                            ? attachment.data.slice()
+                            : (typeof attachment.data === 'string' ? attachment.data : '')
                     }))
                     : [];
 
@@ -6979,7 +6998,7 @@
                 }
 
                 const sanitized = parsed
-                    .filter(item => item && typeof item === 'object' && typeof item.data === 'string')
+                    .filter(item => item && typeof item === 'object' && (typeof item.data === 'string' || Array.isArray(item.data)))
                     .map(item => ({
                         id: item.id || this.generateAttachmentId(),
                         name: item.name || 'Attachment',
@@ -6991,10 +7010,16 @@
                             : (typeof item.size === 'number' ? item.size : 0),
                         compressedSize: typeof item.compressedSize === 'number'
                             ? item.compressedSize
-                            : (typeof item.data === 'string' ? Math.ceil(item.data.length * 3 / 4) : (typeof item.size === 'number' ? item.size : 0)),
+                            : (Array.isArray(item.data)
+                                ? item.data.length
+                                : (typeof item.data === 'string'
+                                    ? Math.ceil(item.data.length * 3 / 4)
+                                    : (typeof item.size === 'number' ? item.size : 0))),
                         lastModified: typeof item.lastModified === 'number' ? item.lastModified : null,
                         addedAt: item.addedAt || new Date().toISOString(),
-                        data: typeof item.data === 'string' ? item.data : ''
+                        data: Array.isArray(item.data)
+                            ? item.data.slice()
+                            : (typeof item.data === 'string' ? item.data : '')
                     }));
 
                 this.attachments = sanitized;
@@ -7230,16 +7255,27 @@
             }
 
             base64ToBlob(base64, mimeType = 'application/octet-stream', isCompressed = false) {
-                const clean = typeof base64 === 'string' ? base64.trim() : '';
-                if (!clean) {
-                    throw new Error('Attachment data is empty.');
-                }
+                let bytes;
 
-                const binary = atob(clean);
-                const length = binary.length;
-                const bytes = new Uint8Array(length);
-                for (let i = 0; i < length; i++) {
-                    bytes[i] = binary.charCodeAt(i);
+                if (Array.isArray(base64)) {
+                    if (!base64.length) {
+                        throw new Error('Attachment data is empty.');
+                    }
+                    bytes = new Uint8Array(base64);
+                } else if (typeof base64 === 'string') {
+                    const clean = base64.trim();
+                    if (!clean) {
+                        throw new Error('Attachment data is empty.');
+                    }
+
+                    const binary = atob(clean);
+                    const length = binary.length;
+                    bytes = new Uint8Array(length);
+                    for (let i = 0; i < length; i++) {
+                        bytes[i] = binary.charCodeAt(i);
+                    }
+                } else {
+                    throw new Error('Invalid attachment data format.');
                 }
 
                 let finalBytes = bytes;


### PR DESCRIPTION
## Summary
- stop base64-encoding attachment uploads and persist raw byte arrays instead
- update attachment storage/restore logic to accept both array and base64 string payloads
- allow blob conversion helper to handle both arrays and legacy base64 strings for backwards compatibility

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_b_68e4055ec0808332bb98ca7355735eac