### PR TITLE
Limit offline bundle contents

### DIFF
--- a/index.html
+++ b/index.html
@@ -8472,10 +8472,7 @@
         const offlineBundleManager = (() => {
             const ZIP_FILENAME = 'personal-health-vault-offline.zip';
             const ASSETS = [
-                { path: 'index.html', type: 'text' },
-                { path: 'translations.json', type: 'text' },
-                { path: 'pako.min.js', type: 'text' },
-                { path: 'jszip.min.js', type: 'text' }
+                { path: 'index.html', type: 'text' }
             ];
 
             const getButtons = () => Array.from(document.querySelectorAll('.offline-download-trigger'));


### PR DESCRIPTION
## Summary
- limit the offline bundle builder to include only the main index.html asset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e732a515908332b58921e75df5ea3b