### PR TITLE
Brand layout deadspace and expand content width

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
         }
 
         :root {
-            --layout-max-width: 1200px;
-            --layout-gutter: clamp(16px, 4vw, 32px);
+            --layout-max-width: 1600px;
+            --layout-gutter: clamp(16px, 2vw, 32px);
             --header-bg: #0f172a;
         }
 
@@ -43,14 +43,34 @@
             font-size: 11pt;
             line-height: 1.5;
             color: #1e293b;
-            background: #f8fafc;
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
             padding: 0;
+            min-height: 100vh;
+        }
+
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-image:
+                radial-gradient(circle at 20% 50%, rgba(59, 130, 246, 0.1) 0%, transparent 50%),
+                radial-gradient(circle at 80% 80%, rgba(6, 182, 212, 0.1) 0%, transparent 50%);
+            pointer-events: none;
+            z-index: 0;
         }
 
         .page-shell {
+            position: relative;
+            z-index: 1;
             width: min(100%, calc(var(--layout-max-width) + (var(--layout-gutter) * 2)));
             margin: 0 auto;
             padding: 0 var(--layout-gutter) 48px;
+            background: #f8fafc;
+            box-shadow: 0 0 60px rgba(0, 0, 0, 0.3);
+            min-height: 100vh;
         }
 
         body:not(:has(#mainContent[style*="display: block"])) .page-shell {
@@ -80,7 +100,7 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -196,6 +216,7 @@
             max-width: 600px;
             margin: 50px auto;
             text-align: center;
+            background: transparent;
         }
         
         .welcome-screen h1 {
@@ -1506,10 +1527,11 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: rgba(0, 0, 0, 0.5);
+            background: rgba(15, 23, 42, 0.8);
             z-index: 2000;
             align-items: center;
             justify-content: center;
+            backdrop-filter: blur(8px);
         }
         
         .modal.active {


### PR DESCRIPTION
## Summary
- widen the layout constraints and body background to introduce branded gradient deadspace
- wrap the main page shell with a light surface, elevated shadow, and subtle decorative pattern
- align welcome, modal, and unlock overlays with the new color palette and transparency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e82caf2008833292036678cedf3e0d