### PR TITLE
Move welcome screen overlay outside page shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,8 +213,14 @@
         }
         
         .welcome-screen {
-            max-width: 600px;
-            margin: 50px auto;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            padding: 64px 24px;
+            overflow-y: auto;
+            z-index: 100;
             text-align: center;
             background: transparent;
         }
@@ -1702,8 +1708,7 @@
             }
 
             .welcome-screen {
-                margin: 30px auto;
-                padding: 0 10px;
+                padding: 32px 16px;
             }
 
             .welcome-screen h1 {
@@ -2338,6 +2343,12 @@
         </div>
     </header>
 
+    <!-- Welcome Screen (shown for new files) -->
+    <div class="welcome-screen" id="welcomeScreen" style="display: none;">
+        <div id="landingRoot"></div>
+        <input type="file" id="vaultFileInput" accept=".ehv" />
+    </div>
+
     <main class="page-shell">
         <div class="nav-tabs no-print" id="navTabs" style="display: none;">
             <div class="tab active" data-section="demographics" data-i18n-key="nav_demographics">📋 Demographics</div>
@@ -2653,12 +2664,6 @@
                 <button class="btn btn-secondary" id="exportCloseBtn">Close</button>
             </div>
         </div>
-    </div>
-
-    <!-- Welcome Screen (shown for new files) -->
-    <div class="welcome-screen" id="welcomeScreen" style="display: none;">
-        <div id="landingRoot"></div>
-        <input type="file" id="vaultFileInput" accept=".ehv" />
     </div>
 
     <!-- Main Content -->


### PR DESCRIPTION
## Summary
- move the welcome screen container outside the page shell so it can overlay the dark background
- update welcome screen styling to occupy the full viewport while keeping the page shell styling intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e830e98fa0833288209c0bb7c2d767