### PR TITLE
Adjust mobile header positioning on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2430,6 +2430,15 @@
         }
         
         @media (max-width: 768px) {
+            .site-header {
+                position: static;
+                width: 100%;
+            }
+
+            body:not(:has(#mainContent[style*="display: block"])) .page-shell {
+                padding-top: var(--layout-gutter);
+            }
+
             .grid-2,
             .grid-3 {
                 grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- make the main site header non-fixed on viewports up to 768px wide to prevent it from covering content
- reduce the top padding on the page shell when the non-fixed header is shown so content spacing remains comfortable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e85627ba24833285e904963e7b2d49