### PR TITLE
Handle Enter key on unlock inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -6056,6 +6056,18 @@
                 document.getElementById('generateRecoveryKeyBtn')?.addEventListener('click', () => this.handleGenerateRecoveryKey());
                 document.getElementById('disableRecoveryKeyBtn')?.addEventListener('click', () => this.handleDisableRecoveryKey());
 
+                ['unlock-password', 'totp-code', 'recovery-key'].forEach((inputId) => {
+                    const input = document.getElementById(inputId);
+                    if (input instanceof HTMLInputElement) {
+                        input.addEventListener('keydown', (event) => {
+                            if (event.key === 'Enter') {
+                                event.preventDefault();
+                                this.attemptUnlock();
+                            }
+                        });
+                    }
+                });
+
                 const profilePhotoInput = document.getElementById('profilePhotoInput');
                 if (profilePhotoInput) {
                     profilePhotoInput.addEventListener('change', (event) => this.handleProfilePhotoSelect(event));


### PR DESCRIPTION
## Summary
- ensure pressing Enter inside the unlock, TOTP, or recovery inputs triggers the unlock workflow
- attach a shared keydown handler during app initialization to keep password entry working smoothly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e942ac034c8332985300e77354cf49