### PR TITLE
Use canonical app code for integrity signature

### DIFF
--- a/index.html
+++ b/index.html
@@ -8632,8 +8632,18 @@
                     .join('\n');
             }
 
+            getCanonicalCodeRepresentation(htmlContent = null) {
+                const source = htmlContent ?? this.getApplicationHTML();
+                const criticalSections = this.extractCriticalCode(source);
+                if (criticalSections && criticalSections.trim().length > 0) {
+                    return criticalSections;
+                }
+
+                return source || '';
+            }
+
             async hashCode(htmlContent) {
-                const criticalSections = this.extractCriticalCode(htmlContent);
+                const canonicalContent = this.getCanonicalCodeRepresentation(htmlContent);
                 const encoder = new TextEncoder();
                 const webCrypto = window.crypto || globalThis.crypto;
 
@@ -8643,7 +8653,7 @@
 
                 const hashBuffer = await webCrypto.subtle.digest(
                     'SHA-256',
-                    encoder.encode(criticalSections || htmlContent)
+                    encoder.encode(canonicalContent)
                 );
 
                 return btoa(String.fromCharCode(...new Uint8Array(hashBuffer)));
@@ -8709,6 +8719,7 @@
                 }
 
                 const htmlContent = this.getApplicationHTML();
+                const canonicalContent = this.getCanonicalCodeRepresentation(htmlContent);
 
                 if (codeHash) {
                     const currentHash = await this.hashCode(htmlContent);
@@ -8720,9 +8731,17 @@
                 if (codeSignature) {
                     const hmacKey = await this.deriveHMACKey(password);
                     if (hmacKey) {
-                        const expectedSignature = await this.createHMAC(hmacKey, htmlContent);
+                        let expectedSignature = '';
+
+                        if (canonicalContent) {
+                            expectedSignature = await this.createHMAC(hmacKey, canonicalContent);
+                        }
+
                         if (expectedSignature && expectedSignature !== codeSignature) {
-                            throw new Error('TAMPERING_DETECTED');
+                            const legacySignature = await this.createHMAC(hmacKey, htmlContent);
+                            if (legacySignature !== codeSignature) {
+                                throw new Error('TAMPERING_DETECTED');
+                            }
                         }
                     }
                 }
@@ -8887,9 +8906,14 @@
 
                 try {
                     const htmlContent = this.getApplicationHTML();
+                    const canonicalContent = this.getCanonicalCodeRepresentation(htmlContent);
                     const codeHash = await this.hashCode(htmlContent);
                     const hmacKey = await this.deriveHMACKey(password);
-                    const codeSignature = await this.createHMAC(hmacKey, htmlContent);
+                    let codeSignature = '';
+
+                    if (hmacKey && canonicalContent) {
+                        codeSignature = await this.createHMAC(hmacKey, canonicalContent);
+                    }
 
                     formData.codeHash = codeHash;
                     formData.codeSignature = codeSignature;


### PR DESCRIPTION
## Summary
- add a helper to derive a canonical application code snapshot for integrity checks
- generate code hashes and HMAC signatures from the canonical representation during save operations
- verify existing signatures using the canonical representation with a legacy fallback for previously saved vaults

## Testing
- Not run (browser-based manual verification required)


------
https://chatgpt.com/codex/tasks/task_b_68e988778314833283c89a4a9a3e67b8