### PR TITLE
Fix vault manager file picker trigger for opening vaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,7 +749,8 @@
             transform: translateY(-2px);
         }
 
-        #vaultFileInput {
+        #vaultFileInput,
+        #vaultManagerFileInput {
             opacity: 0;
             position: absolute;
             width: 0;
@@ -3431,7 +3432,7 @@
         </div>
     </div>
 
-    <input type="file" id="vaultManagerFileInput" accept=".ehv" style="display: none;">
+    <input type="file" id="vaultManagerFileInput" accept=".ehv">
 
     <!-- Accessibility Controls -->
     <div class="a11y-controls" id="a11yControls" role="region" aria-label="Accessibility settings">


### PR DESCRIPTION
## Summary
- allow the vault manager's hidden file input to be triggered by script by matching the existing hidden input styling
- remove inline display:none styling so the operating system file picker opens reliably when users open a vault

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68e9ded4c8188332ac6e98199af09e2c